### PR TITLE
chore: harden repository tooling and standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
-# Public Firebase web configuration. Security is enforced by Firebase rules.
+# COMMITTED TEMPLATE: copy to .env.local for local development.
+# LOCAL ONLY: .env.local is ignored by Git. CI values must come from CI secrets.
+#
+# Public Firebase web configuration. NEXT_PUBLIC_ values are included in the
+# browser bundle by Next.js; authorization must be enforced by Firebase rules.
 NEXT_PUBLIC_FIREBASE_API_KEY=
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 NEXT_PUBLIC_FIREBASE_APP_ID=
+
+# Local-only switch reserved for future emulator adapters. It does not connect
+# the current application automatically.
 NEXT_PUBLIC_USE_FIREBASE_EMULATORS=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+
+*.ico binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Verify
+        run: npm run verify

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 
 # misc
 .DS_Store
+Thumbs.db
+*.swp
 *.pem
 
 # debug

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+coverage/
+out/
+build/
+.firebase/
+package-lock.json
+next-env.d.ts
+*.tsbuildinfo

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "lf"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.useFlatConfig": true,
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,18 @@
 # Coding agent instructions
 
-Before product-code changes, read this file plus `PRODUCT.md`, `ARCHITECTURE.md`, and `DESIGN_SYSTEM.md`.
+`AGENTS.md` is the canonical agent instruction file. Do not add tool-specific copies such as `CLAUDE.md`, `GEMINI.md`, or `CODEX.md` unless a concrete integration cannot reference this file.
+
+Before product-code changes, read this file completely along with `PRODUCT.md`, `ARCHITECTURE.md`, and `DESIGN_SYSTEM.md`. Those four files are the canonical product, architecture, design, and implementation guidance.
 
 - Preserve product invariants: participant-only ballots, one voter/match ballot, hidden in-window aggregates, and club-neutral domain modeling.
 - Keep Herediano-specific names and colors in configuration/presentation, not collection names or generic entities.
 - Prefer Server Components; add `"use client"` only for concrete browser behavior.
-- Keep code simple, typed, and direct. Avoid broad `any`, unnecessary layers, global state libraries, and giant components.
-- Keep imports conventional, unique, and free of unused symbols.
+- Keep code simple, typed, and direct. Keep strict TypeScript enabled, use explicit domain types, infer clear local types, prefer `unknown` to unsafe `any`, and narrow values before use.
+- Order imports as framework/external, internal `@/` imports, then relative imports. Use type-only imports where appropriate. Keep imports conventional, unique, and free of unused symbols; do not add cosmetic barrel files.
+- Prettier is the formatting authority. Run `npm run format` for intentional formatting and do not add stylistic ESLint rules that compete with it. Preserve UTF-8, LF endings, two-space indentation, and final newlines.
 - Update meaningful tests when behavior changes. Test outcomes and accessibility semantics, not implementation trivia.
 - Update source-of-truth documentation when product or architecture truths change.
-- Never commit secrets. Keep local work on emulators or an explicit development Firebase project.
-- Run the complete relevant suite (`npm run verify`) and wait for every process to exit. Never report a command as passing while it is still running.
+- Never commit secrets or local environment files. Keep `.env.example` placeholder-only and keep local work on emulators or an explicit development Firebase project.
+- Do not edit or commit generated output such as `.next`, coverage, emulator data, `next-env.d.ts`, or TypeScript build-info files.
+- Use `npm run verify` as the complete local quality gate: formatting, lint, strict typecheck, all tests, and production build. Also run `git diff --check` before handoff. Wait for every process to exit and never report a command as passing while it is still running.
+- Keep Git changes scoped and preserve unrelated user work. CI must use `npm ci` and invoke the same canonical verification command without production credentials.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -6,17 +6,31 @@ Mobile-first supporter ratings for football matches. The first community is Club
 
 This milestone provides the application shell, design tokens, domain contracts, Firebase boundaries, emulator configuration, and testing/tooling. It does **not** yet authenticate users, sync matches, accept ballots, or show results.
 
-## Local development
+## Developer workflow
 
-Requirements: Node.js 20.9+ and npm.
+Requirements: Node.js 22 and npm. CI uses the same Node major version.
 
 ```bash
-npm install
+npm ci
 copy .env.example .env.local
 npm run dev
 ```
 
-The page works without Firebase values and will not contact a Firebase project. Configure `.env.local` only when working on Firebase functionality. Run `npm run verify` for lint, strict type checking, tests, and a production build.
+The page works without Firebase values and will not contact a Firebase project. `.env.example` is committed, `.env.local` is ignored and developer-owned, and CI variables must be supplied by CI configuration when a future test needs them.
+
+Common commands:
+
+```bash
+npm run dev           # local Next.js server
+npm run format        # write Prettier formatting
+npm run format:check  # check formatting only
+npm run lint          # ESLint
+npm run typecheck     # strict TypeScript check
+npm test              # all Vitest tests once
+npm run test:watch    # Vitest watch mode
+npm run build         # production build
+npm run verify        # canonical complete local/CI quality gate
+```
 
 ## Firebase setup
 
@@ -24,9 +38,21 @@ The page works without Firebase values and will not contact a Firebase project. 
 2. Register a Web app and copy its public config values into `.env.local` (never commit that file).
 3. Enable Anonymous Authentication for the initial voter identity strategy.
 4. Create a Firestore database. Keep the deny-all rules until a tested feature introduces narrower rules.
-5. Install the Firebase CLI separately, select a throwaway project ID, and run `firebase emulators:start` for Auth (9099), Firestore (8080), and Emulator UI (4000).
+5. Install the Firebase CLI separately, select a throwaway project ID, and run:
+
+```bash
+firebase emulators:start --only auth,firestore
+```
+
+Auth runs on 9099, Firestore on 8080, and the Emulator UI on 4000. The Firebase CLI is intentionally not a project dependency because its large dependency tree is unnecessary for application builds. The deny-all Firestore rules remain active in emulator development.
 
 No production credentials, Admin SDK, or deployed Firebase resources are required for this milestone.
+
+## Repository guardrails
+
+Prettier owns formatting, ESLint owns code-quality checks, and strict TypeScript owns static correctness. Optional repository-level VS Code settings align format-on-save with these tools. Pull requests and pushes to `master` run `npm ci` followed by `npm run verify`; CI does not deploy or require Firebase credentials.
+
+There is no pre-commit framework yet. At this repository size, the canonical local gate and CI provide sufficient protection without adding hook lifecycle dependencies. Reconsider lint-staged and Husky only if commit-time feedback becomes a demonstrated need.
 
 ## Source map
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,22 @@
 import { defineConfig, globalIgnores } from "eslint/config";
+import prettier from "eslint-config-prettier/flat";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      "no-duplicate-imports": ["error", { allowSeparateTypeImports: true }],
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", fixStyle: "inline-type-imports" },
+      ],
+    },
+  },
+  // Keep formatting concerns in Prettier, after all other shared configs.
+  prettier,
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
@@ -12,6 +24,7 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "coverage/**",
   ]),
 ]);
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,12 @@
 {
-  "firestore": { "rules": "firestore.rules", "indexes": "firestore.indexes.json" },
-  "emulators": { "auth": { "port": 9099 }, "firestore": { "port": 8080 }, "ui": { "enabled": true, "port": 4000 }, "singleProjectMode": true }
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "auth": { "port": 9099 },
+    "firestore": { "port": 8080 },
+    "ui": { "enabled": true, "port": 4000 },
+    "singleProjectMode": true
+  }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {/* config options here */};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,12 +22,17 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.1.1",
-        "eslint": "^9",
+        "eslint": "^9.39.5",
         "eslint-config-next": "16.3.3",
+        "eslint-config-prettier": "^10.1.8",
         "jsdom": "^29.1.1",
+        "prettier": "^3.9.6",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.11"
+      },
+      "engines": {
+        "node": ">=22 <23"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -594,6 +599,37 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -642,6 +678,37 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -2228,6 +2295,17 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.147.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
@@ -2803,6 +2881,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
@@ -3236,45 +3380,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -3328,19 +3433,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -4115,11 +4207,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.20",
@@ -4144,14 +4239,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4960,42 +5057,25 @@
         }
       }
     },
-    "node_modules/eslint-config-next/node_modules/globals": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
-      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+    "node_modules/eslint-config-next/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "MIT"
     },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
-      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+    "node_modules/eslint-config-next/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.16.1",
-        "resolve": "^2.0.0-next.6"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript": {
+    "node_modules/eslint-config-next/node_modules/eslint-import-resolver-typescript": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
       "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
@@ -5030,35 +5110,7 @@
         }
       }
     },
-    "node_modules/eslint-module-utils": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
-      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
@@ -5092,7 +5144,7 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
@@ -5102,7 +5154,7 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-jsx-a11y": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
@@ -5132,7 +5184,7 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-react": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
@@ -5163,6 +5215,98 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -5203,6 +5347,37 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
@@ -5213,6 +5388,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -5226,6 +5414,19 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.2.1"
       },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6976,16 +7177,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -7488,6 +7692,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -9581,6 +9801,24 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,20 @@
   "name": "rating-app",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22 <23"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify": "npm run lint && npm run typecheck && npm test && npm run build"
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
     "firebase": "^12.18.0",
@@ -27,9 +32,11 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.1.1",
-    "eslint": "^9",
+    "eslint": "^9.39.5",
     "eslint-config-next": "16.3.3",
+    "eslint-config-prettier": "^10.1.8",
     "jsdom": "^29.1.1",
+    "prettier": "^3.9.6",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.11"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,25 +1,79 @@
 @import "tailwindcss";
 
 :root {
-  --color-canvas: #f7f5f0; --color-surface: #ffffff; --color-ink: #211b1b;
-  --color-muted: #675f5f; --color-border: #ded8d1; --color-brand: #b20d24;
-  --color-brand-strong: #8f091c; --color-accent: #f5c518; --color-success: #167449;
-  --color-warning: #9a5b00; --color-danger: #b20d24; --shadow-card: 0 14px 38px rgb(51 29 29 / 8%);
+  --color-canvas: #f7f5f0;
+  --color-surface: #ffffff;
+  --color-ink: #211b1b;
+  --color-muted: #675f5f;
+  --color-border: #ded8d1;
+  --color-brand: #b20d24;
+  --color-brand-strong: #8f091c;
+  --color-accent: #f5c518;
+  --color-success: #167449;
+  --color-warning: #9a5b00;
+  --color-danger: #b20d24;
+  --shadow-card: 0 14px 38px rgb(51 29 29 / 8%);
 }
 @theme inline {
-  --color-background: var(--color-canvas); --color-foreground: var(--color-ink);
-  --color-muted: var(--color-muted); --color-border: var(--color-border);
-  --color-brand: var(--color-brand); --color-accent: var(--color-accent);
-  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --color-background: var(--color-canvas);
+  --color-foreground: var(--color-ink);
+  --color-muted: var(--color-muted);
+  --color-border: var(--color-border);
+  --color-brand: var(--color-brand);
+  --color-accent: var(--color-accent);
+  --font-sans:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
 }
-* { box-sizing: border-box; }
-html { background: var(--color-canvas); }
-body { margin: 0; background: var(--color-canvas); color: var(--color-ink); font-family: var(--font-sans); }
-a { color: inherit; }
-:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 3px; }
-.page-shell { width: min(100% - 2rem, 68rem); margin-inline: auto; }
-.eyebrow { color: var(--color-brand); font-size: .75rem; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
-.text-muted { color: var(--color-muted); }
-.card { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 1.25rem; box-shadow: var(--shadow-card); }
-@media (min-width: 640px) { .page-shell { width: min(100% - 3rem, 68rem); } }
-@media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; } }
+* {
+  box-sizing: border-box;
+}
+html {
+  background: var(--color-canvas);
+}
+body {
+  margin: 0;
+  background: var(--color-canvas);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+}
+a {
+  color: inherit;
+}
+:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 3px;
+}
+.page-shell {
+  width: min(100% - 2rem, 68rem);
+  margin-inline: auto;
+}
+.eyebrow {
+  color: var(--color-brand);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.text-muted {
+  color: var(--color-muted);
+}
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 1.25rem;
+  box-shadow: var(--shadow-card);
+}
+@media (min-width: 640px) {
+  .page-shell {
+    width: min(100% - 3rem, 68rem);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,8 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Rating App",
-  description: "Supporter ratings for the players and coaches who shape the match.",
+  description:
+    "Supporter ratings for the players and coaches who shape the match.",
 };
 
 export default function RootLayout({ children }: LayoutProps<"/">) {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -5,20 +5,38 @@ import Home from "./page";
 describe("Home", () => {
   it("presents the initial club and an honest inactive state", () => {
     render(<Home />);
-    expect(screen.getByRole("heading", { name: "Club Sport Herediano" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "No active rating" })).toBeInTheDocument();
-    expect(screen.getByText(/results stay hidden while voting is open/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Club Sport Herediano" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "No active rating" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/results stay hidden while voting is open/i),
+    ).toBeInTheDocument();
   });
   it("exposes semantic primary navigation with future destinations disabled", () => {
     render(<Home />);
-    const navigation = screen.getByRole("navigation", { name: "Primary navigation" });
-    expect(within(navigation).getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
-    expect(within(navigation).getByText("Matches")).toHaveAttribute("aria-disabled", "true");
-    expect(within(navigation).getByText("Players")).toHaveAttribute("aria-disabled", "true");
+    const navigation = screen.getByRole("navigation", {
+      name: "Primary navigation",
+    });
+    expect(
+      within(navigation).getByRole("link", { name: "Home" }),
+    ).toHaveAttribute("href", "/");
+    expect(within(navigation).getByText("Matches")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(within(navigation).getByText("Players")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
   it("provides a keyboard skip link and a labeled main region", () => {
     render(<Home />);
-    expect(screen.getByRole("link", { name: "Skip to content" })).toHaveAttribute("href", "#main-content");
+    expect(
+      screen.getByRole("link", { name: "Skip to content" }),
+    ).toHaveAttribute("href", "#main-content");
     expect(screen.getByRole("main")).toHaveAttribute("id", "main-content");
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,14 +3,24 @@ import { EmptyRatingState } from "@/components/empty-rating-state";
 import { initialClub } from "@/config/club";
 
 export default function Home() {
-  return <AppShell>
-    <main id="main-content" className="page-shell py-8 sm:py-12">
-      <section aria-labelledby="club-heading" className="mb-8">
-        <p className="eyebrow">Initial supporter community</p>
-        <h1 id="club-heading" className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl">{initialClub.displayName}</h1>
-        <p className="mt-3 max-w-xl text-base leading-7 text-muted">Rate the players and head coach after the final whistle. The first rating window will appear here when a match is ready.</p>
-      </section>
-      <EmptyRatingState />
-    </main>
-  </AppShell>;
+  return (
+    <AppShell>
+      <main id="main-content" className="page-shell py-8 sm:py-12">
+        <section aria-labelledby="club-heading" className="mb-8">
+          <p className="eyebrow">Initial supporter community</p>
+          <h1
+            id="club-heading"
+            className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl"
+          >
+            {initialClub.displayName}
+          </h1>
+          <p className="mt-3 max-w-xl text-base leading-7 text-muted">
+            Rate the players and head coach after the final whistle. The first
+            rating window will appear here when a match is ready.
+          </p>
+        </section>
+        <EmptyRatingState />
+      </main>
+    </AppShell>
+  );
 }

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -8,13 +8,59 @@ const navigation = [
 ] as const;
 
 export function AppShell({ children }: { children: ReactNode }) {
-  return <div className="min-h-screen">
-    <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-3">Skip to content</a>
-    <header className="border-b border-border bg-white"><div className="page-shell flex min-h-18 items-center justify-between gap-4">
-      <Link href="/" aria-label="Rating App home" className="flex min-h-11 items-center gap-3 rounded-md"><span aria-hidden="true" className="grid size-9 place-items-center rounded-xl bg-brand font-black text-white">R</span><span className="font-extrabold tracking-tight">Rating App</span></Link>
-      <nav aria-label="Primary navigation"><ul className="flex items-center gap-1">{navigation.map((item) => <li key={item.href}>{item.planned ? <span aria-disabled="true" className="flex min-h-11 items-center rounded-lg px-3 text-sm font-semibold text-muted opacity-65">{item.label}</span> : <Link href={item.href} aria-current="page" className="flex min-h-11 items-center rounded-lg bg-red-50 px-3 text-sm font-bold text-brand">{item.label}</Link>}</li>)}</ul></nav>
-    </div></header>
-    {children}
-    <footer className="page-shell border-t border-border py-6 text-sm text-muted">Built for supporters. Ready to grow club by club.</footer>
-  </div>;
+  return (
+    <div className="min-h-screen">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-3"
+      >
+        Skip to content
+      </a>
+      <header className="border-b border-border bg-white">
+        <div className="page-shell flex min-h-18 items-center justify-between gap-4">
+          <Link
+            href="/"
+            aria-label="Rating App home"
+            className="flex min-h-11 items-center gap-3 rounded-md"
+          >
+            <span
+              aria-hidden="true"
+              className="grid size-9 place-items-center rounded-xl bg-brand font-black text-white"
+            >
+              R
+            </span>
+            <span className="font-extrabold tracking-tight">Rating App</span>
+          </Link>
+          <nav aria-label="Primary navigation">
+            <ul className="flex items-center gap-1">
+              {navigation.map((item) => (
+                <li key={item.href}>
+                  {item.planned ? (
+                    <span
+                      aria-disabled="true"
+                      className="flex min-h-11 items-center rounded-lg px-3 text-sm font-semibold text-muted opacity-65"
+                    >
+                      {item.label}
+                    </span>
+                  ) : (
+                    <Link
+                      href={item.href}
+                      aria-current="page"
+                      className="flex min-h-11 items-center rounded-lg bg-red-50 px-3 text-sm font-bold text-brand"
+                    >
+                      {item.label}
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </header>
+      {children}
+      <footer className="page-shell border-t border-border py-6 text-sm text-muted">
+        Built for supporters. Ready to grow club by club.
+      </footer>
+    </div>
+  );
 }

--- a/src/components/empty-rating-state.tsx
+++ b/src/components/empty-rating-state.tsx
@@ -1,11 +1,23 @@
 export function EmptyRatingState() {
-  return <section aria-labelledby="rating-status" className="card overflow-hidden">
-    <div className="h-2 bg-[linear-gradient(90deg,var(--color-brand)_0_70%,var(--color-accent)_70%)]" />
-    <div className="px-5 py-8 sm:px-8 sm:py-10">
-      <span className="inline-flex min-h-8 items-center rounded-full bg-stone-100 px-3 text-xs font-bold uppercase tracking-wide text-muted">Voting closed</span>
-      <h2 id="rating-status" className="mt-5 text-2xl font-bold">No active rating</h2>
-      <p className="mt-2 max-w-lg leading-7 text-muted">The next rating will appear after a match. Only players who took part, plus the head coach, will be eligible for your ballot.</p>
-      <p className="mt-6 border-l-4 border-accent pl-4 text-sm font-semibold">Results stay hidden while voting is open to keep every rating independent.</p>
-    </div>
-  </section>;
+  return (
+    <section aria-labelledby="rating-status" className="card overflow-hidden">
+      <div className="h-2 bg-[linear-gradient(90deg,var(--color-brand)_0_70%,var(--color-accent)_70%)]" />
+      <div className="px-5 py-8 sm:px-8 sm:py-10">
+        <span className="inline-flex min-h-8 items-center rounded-full bg-stone-100 px-3 text-xs font-bold uppercase tracking-wide text-muted">
+          Voting closed
+        </span>
+        <h2 id="rating-status" className="mt-5 text-2xl font-bold">
+          No active rating
+        </h2>
+        <p className="mt-2 max-w-lg leading-7 text-muted">
+          The next rating will appear after a match. Only players who took part,
+          plus the head coach, will be eligible for your ballot.
+        </p>
+        <p className="mt-6 border-l-4 border-accent pl-4 text-sm font-semibold">
+          Results stay hidden while voting is open to keep every rating
+          independent.
+        </p>
+      </div>
+    </section>
+  );
 }

--- a/src/config/club.ts
+++ b/src/config/club.ts
@@ -2,6 +2,8 @@ import type { TeamPresentation } from "@/domain/models";
 
 /** Presentation configuration only; Herediano is not embedded in domain models. */
 export const initialClub: TeamPresentation = {
-  teamId: "club-sport-herediano", displayName: "Club Sport Herediano", shortName: "Herediano",
+  teamId: "club-sport-herediano",
+  displayName: "Club Sport Herediano",
+  shortName: "Herediano",
   theme: { primary: "#b20d24", accent: "#f5c518" },
 };

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1,14 +1,82 @@
 export type EntityId = string;
-export interface Team { id: EntityId; name: string; countryCode: string; externalProviderId?: string; }
-export interface Competition { id: EntityId; name: string; countryCode?: string; externalProviderId?: string; }
-export interface Season { id: EntityId; competitionId: EntityId; name: string; startsAt: string; endsAt: string; }
-export type MatchStatus = "scheduled" | "live" | "finished" | "postponed" | "cancelled";
-export interface Match { id: EntityId; teamId: EntityId; opponentTeamId: EntityId; competitionId: EntityId; seasonId: EntityId; homeTeamId: EntityId; awayTeamId: EntityId; kickoffAt: string; status: MatchStatus; score?: { home: number; away: number }; votingOpensAt?: string; votingClosesAt?: string; externalProviderFixtureId?: string; }
-export interface Player { id: EntityId; name: string; externalProviderPlayerId?: string; }
+export interface Team {
+  id: EntityId;
+  name: string;
+  countryCode: string;
+  externalProviderId?: string;
+}
+export interface Competition {
+  id: EntityId;
+  name: string;
+  countryCode?: string;
+  externalProviderId?: string;
+}
+export interface Season {
+  id: EntityId;
+  competitionId: EntityId;
+  name: string;
+  startsAt: string;
+  endsAt: string;
+}
+export type MatchStatus =
+  "scheduled" | "live" | "finished" | "postponed" | "cancelled";
+export interface Match {
+  id: EntityId;
+  teamId: EntityId;
+  opponentTeamId: EntityId;
+  competitionId: EntityId;
+  seasonId: EntityId;
+  homeTeamId: EntityId;
+  awayTeamId: EntityId;
+  kickoffAt: string;
+  status: MatchStatus;
+  score?: { home: number; away: number };
+  votingOpensAt?: string;
+  votingClosesAt?: string;
+  externalProviderFixtureId?: string;
+}
+export interface Player {
+  id: EntityId;
+  name: string;
+  externalProviderPlayerId?: string;
+}
 export type SquadRole = "starter" | "substitute";
-export interface MatchParticipant { matchId: EntityId; playerId: EntityId; squadRole: SquadRole; participated: boolean; enteredAtMinute?: number; leftAtMinute?: number; }
-export interface CoachAssignment { matchId: EntityId; coachId: EntityId; teamId: EntityId; }
-export interface Coach { id: EntityId; name: string; externalProviderCoachId?: string; }
-export interface Ballot { id: EntityId; matchId: EntityId; voterId: EntityId; submittedAt: string; playerRatings: Record<EntityId, number>; coachRating: { coachId: EntityId; rating: number }; }
-export interface MatchRatingAggregate { matchId: EntityId; ballotCount: number; playerAverages: Record<EntityId, number>; coachAverage: number; updatedAt: string; }
-export interface TeamPresentation { teamId: EntityId; displayName: string; shortName: string; theme: { primary: string; accent: string }; }
+export interface MatchParticipant {
+  matchId: EntityId;
+  playerId: EntityId;
+  squadRole: SquadRole;
+  participated: boolean;
+  enteredAtMinute?: number;
+  leftAtMinute?: number;
+}
+export interface CoachAssignment {
+  matchId: EntityId;
+  coachId: EntityId;
+  teamId: EntityId;
+}
+export interface Coach {
+  id: EntityId;
+  name: string;
+  externalProviderCoachId?: string;
+}
+export interface Ballot {
+  id: EntityId;
+  matchId: EntityId;
+  voterId: EntityId;
+  submittedAt: string;
+  playerRatings: Record<EntityId, number>;
+  coachRating: { coachId: EntityId; rating: number };
+}
+export interface MatchRatingAggregate {
+  matchId: EntityId;
+  ballotCount: number;
+  playerAverages: Record<EntityId, number>;
+  coachAverage: number;
+  updatedAt: string;
+}
+export interface TeamPresentation {
+  teamId: EntityId;
+  displayName: string;
+  shortName: string;
+  theme: { primary: string; accent: string };
+}

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -1,3 +1,12 @@
 import type { Ballot, EntityId, Match, MatchParticipant } from "./models";
-export interface MatchDataProvider { getMatch(externalFixtureId: string): Promise<Match>; getParticipants(externalFixtureId: string): Promise<MatchParticipant[]>; }
-export interface BallotStore { submitOnce(ballot: Ballot): Promise<void>; findByVoterAndMatch(voterId: EntityId, matchId: EntityId): Promise<Ballot | null>; }
+export interface MatchDataProvider {
+  getMatch(externalFixtureId: string): Promise<Match>;
+  getParticipants(externalFixtureId: string): Promise<MatchParticipant[]>;
+}
+export interface BallotStore {
+  submitOnce(ballot: Ballot): Promise<void>;
+  findByVoterAndMatch(
+    voterId: EntityId,
+    matchId: EntityId,
+  ): Promise<Ballot | null>;
+}

--- a/src/lib/firebase/browser.ts
+++ b/src/lib/firebase/browser.ts
@@ -2,7 +2,12 @@ import { getApp, getApps, initializeApp, type FirebaseApp } from "firebase/app";
 import { firebaseEnvironment, isFirebaseConfigured } from "./config";
 
 export function getBrowserFirebaseApp(): FirebaseApp {
-  if (!isFirebaseConfigured) throw new Error("Firebase browser configuration is missing. See .env.example.");
+  if (!isFirebaseConfigured)
+    throw new Error(
+      "Firebase browser configuration is missing. See .env.example.",
+    );
   return getApps()[0] ?? initializeApp(firebaseEnvironment);
 }
-export function getExistingBrowserFirebaseApp(): FirebaseApp | null { return getApps().length > 0 ? getApp() : null; }
+export function getExistingBrowserFirebaseApp(): FirebaseApp | null {
+  return getApps().length > 0 ? getApp() : null;
+}

--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -6,4 +6,5 @@ export const firebaseEnvironment = {
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
-export const isFirebaseConfigured = Object.values(firebaseEnvironment).every(Boolean);
+export const isFirebaseConfigured =
+  Object.values(firebaseEnvironment).every(Boolean);

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,5 +4,9 @@ import { fileURLToPath } from "node:url";
 export default defineConfig({
   plugins: [react()],
   resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
-  test: { environment: "jsdom", setupFiles: ["./vitest.setup.ts"], globals: true },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary

- add Prettier formatting with `format` and `format:check`
- add `.editorconfig`, `.gitattributes`, and repository-safe VS Code settings
- strengthen flat ESLint configuration for duplicate imports and type-only imports
- standardize Node 22 and canonical `npm run verify` workflow
- add GitHub Actions CI for pull requests and pushes to `master`
- clarify Firebase emulator and environment-file conventions
- expand repository standards in `AGENTS.md` and developer workflow in `README.md`
- remove redundant `CLAUDE.md`
- mechanically reformat the existing small codebase without changing product behavior or domain semantics

## Tooling decisions

- Prettier 3 is the formatting authority; ESLint formatting rules are disabled through `eslint-config-prettier`.
- Strict TypeScript remains unchanged.
- Pre-commit hooks are intentionally deferred while the repository is small; CI and `npm run verify` provide the quality gate.
- Firebase CLI remains an external development dependency rather than a project dependency due to its large transitive dependency tree.
- ESLint remains on 9.39.5 because the current Next.js/plugin dependency tree has valid peer compatibility there.

## Verification

Local verification completed successfully before opening this PR:

- `npm ls eslint --depth=2` — passed
- `npm run format:check` — passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm test` — 3/3 tests passed
- `npm run build` — passed; `/` statically generated
- `npm run verify` — passed with exit code 0
- `git diff --check` — passed
- dependency audit — zero vulnerabilities

## Manual follow-up

No production Firebase configuration or deployment is required for this change. Firebase Emulator Suite remains optional via an externally installed Firebase CLI.