### PR TITLE
feat: add Firebase team persistence foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 #
 # Public Firebase web configuration. NEXT_PUBLIC_ values are included in the
 # browser bundle by Next.js; authorization must be enforced by Firebase rules.
+NEXT_PUBLIC_FIREBASE_ENVIRONMENT=local
 NEXT_PUBLIC_FIREBASE_API_KEY=
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=
@@ -10,6 +11,7 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 NEXT_PUBLIC_FIREBASE_APP_ID=
 
-# Local-only switch reserved for future emulator adapters. It does not connect
-# the current application automatically.
-NEXT_PUBLIC_USE_FIREBASE_EMULATORS=true
+# Local mode always connects Firestore to these endpoints and never falls back
+# to a cloud project. Development and production require complete web config.
+NEXT_PUBLIC_FIRESTORE_EMULATOR_HOST=127.0.0.1
+NEXT_PUBLIC_FIRESTORE_EMULATOR_PORT=8080

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "demo-rating-app-local"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,7 @@ jobs:
         run: npm ci
       - name: Verify
         run: npm run verify
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools@15.28.2
+      - name: Test Firestore integration and rules
+        run: npm run test:firebase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
         run: npm ci
       - name: Verify
         run: npm run verify
+      - name: Use Java 21
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: 21
       - name: Install Firebase CLI
         run: npm install --global firebase-tools@15.28.2
       - name: Test Firestore integration and rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Before product-code changes, read this file completely along with `PRODUCT.md`, 
 - Update meaningful tests when behavior changes. Test outcomes and accessibility semantics, not implementation trivia.
 - Update source-of-truth documentation when product or architecture truths change.
 - Never commit secrets or local environment files. Keep `.env.example` placeholder-only and keep local work on emulators or an explicit development Firebase project.
+- Treat `teams/{teamId}` as public-readable and client-write-denied. Seed only through the explicit emulator bootstrap; never seed from rendering or application startup and never weaken rules for convenience.
+- Run `npm run test:firebase` for Firestore persistence or rules changes. It requires Java and the externally installed Firebase CLI; CI runs it separately from the standard gate.
 - Do not edit or commit generated output such as `.next`, coverage, emulator data, `next-env.d.ts`, or TypeScript build-info files.
 - Use `npm run verify` as the complete local quality gate: formatting, lint, strict typecheck, all tests, and production build. Also run `git diff --check` before handoff. Wait for every process to exit and never report a command as passing while it is still running.
 - Keep Git changes scoped and preserve unrelated user work. CI must use `npm ci` and invoke the same canonical verification command without production credentials.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 Next.js App Router and strict TypeScript form the web application. Pages and layouts are Server Components by default; use Client Components only for browser state or interaction. Tailwind CSS consumes semantic tokens. Domain types and ports do not import Firebase or React.
 
-`src/config` selects the initial club presentation. `src/domain` describes stable business concepts. `src/lib/firebase/browser.ts` lazily initializes the web SDK only when called and configured. A separate server module reserves the privileged boundary; Firebase Admin is deliberately absent until a concrete server use case exists.
+`src/config` selects the initial club presentation. `src/domain` describes stable business concepts. `src/lib/firebase/browser.ts` lazily initializes the web SDK only when called and configured. Local mode always connects Firestore to the explicitly configured emulator and never falls back to a cloud project. Development and production modes require complete Firebase Web configuration. A separate server module reserves the privileged boundary; Firebase Admin remains absent because browser reads and an emulator-only bootstrap cover this milestone.
 
 ## Proposed Firestore model
 
@@ -25,6 +25,10 @@ players/{playerId}/matchSummaries/{matchId}
 players/{playerId}/statistics/{seasonOrCareerId}
 ```
 
+The implemented `teams/{teamId}` document contains `displayName`, `shortName`, `countryCode`, `brandingKey`, optional `externalProviderId`, and Firestore `createdAt`/`updatedAt` timestamps. `club-sport-herediano` is the stable initial ID. The seed JSON is the canonical basic Team data; presentation configuration derives its identity and names from that record while keeping theme colors in source code. Firestore snapshots are converted and runtime-validated at the persistence boundary before becoming domain `Team` values.
+
+An explicit emulator-only script ensures the initial document exists. It requires a local emulator host and a `demo-*` project ID, creates only when absent, and leaves an existing record untouched. It never runs during application rendering or startup.
+
 A match stores tracked team, opponent, home/away IDs, competition, season, kickoff, status, score, provider fixture ID, and voting bounds. A participant stores squad role (`starter` or `substitute`), `participated`, and optional entry/exit minutes. Ballot queries and validation must include only `participated == true` records.
 
 A completed ballot is one document containing a map of player IDs to ratings and one coach rating. Its document ID is the authenticated `voterId` inside the match's `ballots` subcollection. A Firestore transaction creates only if absent; security rules require `request.auth.uid == voterId`, immutable match/voter identity, a valid open window, and eligible rating keys. A server-controlled match state is authoritative. This deterministic path plus transaction and rules enforces `one voter + one match` without a per-score write explosion.
@@ -35,7 +39,7 @@ On accepted ballot creation, a future trusted Cloud Function transaction updates
 
 ## Authentication and security
 
-Start with Firebase Anonymous Authentication for low friction. Domain data keys by Firebase UID, so upgrading or linking an anonymous account to Google, email link, or another provider preserves identity. Authentication is not authorization: Firestore rules validate document ownership, match state, window bounds, rating ranges, and allowed keys. Default rules currently deny every read and write.
+Start with Firebase Anonymous Authentication for low friction. Domain data keys by Firebase UID, so upgrading or linking an anonymous account to Google, email link, or another provider preserves identity. Authentication is not authorization: future Firestore rules will validate document ownership, match state, window bounds, rating ranges, and allowed keys. Team documents are intentionally public-readable because the product displays club identity without authentication; all browser Team writes remain denied, and every other collection remains deny-all. Development bootstrap uses the emulator's privileged REST context and cannot target a non-local host or non-demo project.
 
 Never expose Admin credentials to the browser. Public Firebase web configuration is not secret, but belongs in environment-specific files. Use separate development/production projects and emulators for local work. Validate App Check and abuse controls before public launch.
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -6,9 +6,9 @@ Rating App gives a small football supporter community a fair, simple way to rate
 
 ## Current foundation milestone
 
-Implemented now: a mobile-first shell showing Herediano as the initial configured club, an honest inactive-voting state, future navigation affordances, accessible semantics, generic domain types, and project infrastructure.
+Implemented now: a mobile-first shell showing Herediano as the initial configured club, an honest inactive-voting state, future navigation affordances, accessible semantics, generic domain types, project infrastructure, and a Firestore-backed Team persistence foundation. Club Sport Herediano is the first deterministic Team record and can be bootstrapped explicitly in the local emulator.
 
-Not implemented now: live match data, authentication, voting, ratings, aggregates, history pages, notifications, administration, or API-Football integration. The UI must not imply these exist.
+Not implemented now: cloud Team administration, live match data, authentication, voting, ratings, aggregates, history pages, notifications, administration, or API-Football integration. The UI still uses the configured presentation fallback and must not imply these exist.
 
 ## MVP (planned)
 

--- a/README.md
+++ b/README.md
@@ -28,25 +28,36 @@ npm run lint          # ESLint
 npm run typecheck     # strict TypeScript check
 npm test              # all Vitest tests once
 npm run test:watch    # Vitest watch mode
+npm run test:firebase # Firestore persistence and security-rule tests
 npm run build         # production build
 npm run verify        # canonical complete local/CI quality gate
 ```
 
 ## Firebase setup
 
-1. Create separate Firebase projects for development and production when persistence work begins.
-2. Register a Web app and copy its public config values into `.env.local` (never commit that file).
-3. Enable Anonymous Authentication for the initial voter identity strategy.
-4. Create a Firestore database. Keep the deny-all rules until a tested feature introduces narrower rules.
-5. Install the Firebase CLI separately, select a throwaway project ID, and run:
+Firebase environments are explicit:
+
+- `local` always uses the Firestore Emulator and defaults to the safe `demo-rating-app-local` project ID.
+- `development` requires a complete Firebase Web configuration for a separate cloud development project.
+- `production` requires a complete production Web configuration and must never be used for local seeding or tests.
+
+For local persistence work, install Java and Firebase CLI 15.28.2 separately, copy `.env.example` to `.env.local`, and run:
 
 ```bash
-firebase emulators:start --only auth,firestore
+npm run firebase:emulators
 ```
 
-Auth runs on 9099, Firestore on 8080, and the Emulator UI on 4000. The Firebase CLI is intentionally not a project dependency because its large dependency tree is unnecessary for application builds. The deny-all Firestore rules remain active in emulator development.
+Firestore runs on 8080 and the Emulator UI on 4000. In another terminal, explicitly bootstrap the deterministic initial Team:
 
-No production credentials, Admin SDK, or deployed Firebase resources are required for this milestone.
+```bash
+npm run seed:firebase
+```
+
+The bootstrap targets `127.0.0.1:8080` by default, accepts only a local host and `demo-*` project ID, creates `teams/club-sport-herediano` only when absent, and never runs during app startup. Run `npm run test:firebase` to start an isolated emulator, verify persistence and rules, then stop it.
+
+`teams/{teamId}` is public-readable and denies all browser writes. Every other collection remains deny-all. The Firebase CLI is intentionally not a project dependency because its large dependency tree is unnecessary for application builds. CI installs a pinned CLI version separately and runs the emulator suite after `npm run verify`.
+
+To use a cloud development project later, register a Web app, set `NEXT_PUBLIC_FIREBASE_ENVIRONMENT=development`, and provide every public Firebase value in `.env.local`. Do not reuse production values. No production credentials, Admin SDK, or deployed Firebase resources are required for this milestone.
 
 ## Repository guardrails
 

--- a/firebase/seed/initial-team.json
+++ b/firebase/seed/initial-team.json
@@ -1,0 +1,7 @@
+{
+  "id": "club-sport-herediano",
+  "displayName": "Club Sport Herediano",
+  "shortName": "Herediano",
+  "countryCode": "CR",
+  "brandingKey": "herediano"
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,13 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Foundation default: deny all. Add least-privilege rules with each capability.
-    match /{document=**} { allow read, write: if false; }
+    match /teams/{teamId} {
+      allow read: if true;
+      allow create, update, delete: if false;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "19.2.8"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^5.0.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.3",
@@ -1333,6 +1334,19 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.2.tgz",
       "integrity": "sha512-i8k1omVfoAnaT1ZPv2FFjxMZrATYsO/GnFgHEj5+7fAJLzi8wLnGGv1WK06oEAD6ltrWXSO1HzeNyajn/NjMWw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.2.tgz",
+      "integrity": "sha512-g053AaFcuf4gpAQbwRK/GIIGfPHhpomW3qkIYLi4xnaTUrf65yGP+0TPdojoXfB/ejrfevkXmMs5qXOTSwdN6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^12.0.0"
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:firebase": "firebase emulators:exec --only firestore \"npm run test:firebase:run\"",
+    "test:firebase:run": "vitest run --config vitest.firebase.config.mts",
+    "firebase:emulators": "firebase emulators:start --only firestore",
+    "seed:firebase": "node scripts/seed-development.mjs",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
@@ -24,6 +28,7 @@
     "react-dom": "19.2.8"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^5.0.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.3",

--- a/scripts/seed-development.d.mts
+++ b/scripts/seed-development.d.mts
@@ -1,0 +1,4 @@
+export function ensureDevelopmentTeam(options?: {
+  emulatorHost?: string;
+  projectId?: string;
+}): Promise<{ created: boolean; teamId: string }>;

--- a/scripts/seed-development.mjs
+++ b/scripts/seed-development.mjs
@@ -1,0 +1,77 @@
+import { pathToFileURL } from "node:url";
+
+import initialTeam from "../firebase/seed/initial-team.json" with { type: "json" };
+
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]"]);
+
+function parseEmulatorHost(value) {
+  if (!value) throw new Error("FIRESTORE_EMULATOR_HOST is required.");
+  const separator = value.lastIndexOf(":");
+  if (separator < 1)
+    throw new Error("FIRESTORE_EMULATOR_HOST must include a port.");
+  const host = value.slice(0, separator);
+  const port = Number(value.slice(separator + 1));
+  if (!LOCAL_HOSTS.has(host) || !Number.isInteger(port)) {
+    throw new Error(
+      "Development seeding is restricted to a local Firestore emulator.",
+    );
+  }
+  return { host, port };
+}
+
+function stringValue(value) {
+  return { stringValue: value };
+}
+
+export async function ensureDevelopmentTeam({
+  emulatorHost = process.env.FIRESTORE_EMULATOR_HOST ?? "127.0.0.1:8080",
+  projectId = process.env.GCLOUD_PROJECT ?? "demo-rating-app-local",
+} = {}) {
+  if (!projectId.startsWith("demo-")) {
+    throw new Error(
+      "Development seeding requires a demo-* Firebase project ID.",
+    );
+  }
+  const { host, port } = parseEmulatorHost(emulatorHost);
+  const baseUrl = `http://${host}:${port}/v1/projects/${projectId}/databases/(default)/documents`;
+  const existing = await fetch(`${baseUrl}/teams/${initialTeam.id}`, {
+    headers: { Authorization: "Bearer owner" },
+  });
+
+  if (existing.ok) return { created: false, teamId: initialTeam.id };
+  if (existing.status !== 404) {
+    throw new Error(`Could not inspect Team document (${existing.status}).`);
+  }
+
+  const now = new Date().toISOString();
+  const created = await fetch(`${baseUrl}/teams?documentId=${initialTeam.id}`, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer owner",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      fields: {
+        displayName: stringValue(initialTeam.displayName),
+        shortName: stringValue(initialTeam.shortName),
+        countryCode: stringValue(initialTeam.countryCode),
+        brandingKey: stringValue(initialTeam.brandingKey),
+        createdAt: { timestampValue: now },
+        updatedAt: { timestampValue: now },
+      },
+    }),
+  });
+  if (!created.ok) {
+    throw new Error(`Could not create Team document (${created.status}).`);
+  }
+  return { created: true, teamId: initialTeam.id };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await ensureDevelopmentTeam();
+  console.log(
+    result.created
+      ? `Created teams/${result.teamId}.`
+      : `teams/${result.teamId} already exists; no changes made.`,
+  );
+}

--- a/scripts/seed-development.test.mts
+++ b/scripts/seed-development.test.mts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { ensureDevelopmentTeam } from "./seed-development.mjs";
+
+describe("development Team seed safety", () => {
+  it("rejects non-local Firestore hosts before making a request", async () => {
+    await expect(
+      ensureDevelopmentTeam({
+        emulatorHost: "firestore.googleapis.com:443",
+        projectId: "demo-rating-app-local",
+      }),
+    ).rejects.toThrow("restricted to a local Firestore emulator");
+  });
+
+  it("rejects non-demo project IDs", async () => {
+    await expect(
+      ensureDevelopmentTeam({
+        emulatorHost: "127.0.0.1:8080",
+        projectId: "rating-app-production",
+      }),
+    ).rejects.toThrow("requires a demo-* Firebase project ID");
+  });
+});

--- a/src/config/club.ts
+++ b/src/config/club.ts
@@ -1,9 +1,10 @@
 import type { TeamPresentation } from "@/domain/models";
+import initialTeam from "../../firebase/seed/initial-team.json";
 
 /** Presentation configuration only; Herediano is not embedded in domain models. */
 export const initialClub: TeamPresentation = {
-  teamId: "club-sport-herediano",
-  displayName: "Club Sport Herediano",
-  shortName: "Herediano",
+  teamId: initialTeam.id,
+  displayName: initialTeam.displayName,
+  shortName: initialTeam.shortName,
   theme: { primary: "#b20d24", accent: "#f5c518" },
 };

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1,9 +1,13 @@
 export type EntityId = string;
 export interface Team {
   id: EntityId;
-  name: string;
+  displayName: string;
+  shortName: string;
   countryCode: string;
   externalProviderId?: string;
+  brandingKey: string;
+  createdAt: string;
+  updatedAt: string;
 }
 export interface Competition {
   id: EntityId;

--- a/src/lib/firebase/browser.ts
+++ b/src/lib/firebase/browser.ts
@@ -1,13 +1,60 @@
 import { getApp, getApps, initializeApp, type FirebaseApp } from "firebase/app";
-import { firebaseEnvironment, isFirebaseConfigured } from "./config";
+import {
+  connectFirestoreEmulator,
+  getFirestore,
+  type Firestore,
+} from "firebase/firestore";
+
+import {
+  firebaseEnvironment,
+  firebaseEnvironmentName,
+  firestoreEmulator,
+  isFirebaseConfigured,
+} from "./config";
+
+const LOCAL_PROJECT_ID = "demo-rating-app-local";
+const emulatorConnections = globalThis as typeof globalThis & {
+  __ratingAppFirestoreEmulators?: Set<string>;
+};
 
 export function getBrowserFirebaseApp(): FirebaseApp {
-  if (!isFirebaseConfigured)
+  if (!isFirebaseConfigured) {
     throw new Error(
-      "Firebase browser configuration is missing. See .env.example.",
+      "Firebase environment configuration is missing or invalid. See .env.example.",
     );
-  return getApps()[0] ?? initializeApp(firebaseEnvironment);
+  }
+
+  const options =
+    firebaseEnvironmentName === "local"
+      ? { projectId: firebaseEnvironment.projectId ?? LOCAL_PROJECT_ID }
+      : firebaseEnvironment;
+
+  return getApps()[0] ?? initializeApp(options);
 }
+
+export function getBrowserFirestore(): Firestore {
+  const app = getBrowserFirebaseApp();
+  const database = getFirestore(app);
+
+  if (firebaseEnvironmentName === "local") {
+    if (!Number.isInteger(firestoreEmulator.port)) {
+      throw new Error("Firestore emulator port must be an integer.");
+    }
+    const connections = (emulatorConnections.__ratingAppFirestoreEmulators ??=
+      new Set<string>());
+    if (!connections.has(app.name)) {
+      connectFirestoreEmulator(
+        database,
+        firestoreEmulator.host,
+        firestoreEmulator.port,
+      );
+      connections.add(app.name);
+    }
+  }
+
+  return database;
+}
+
 export function getExistingBrowserFirebaseApp(): FirebaseApp | null {
   return getApps().length > 0 ? getApp() : null;
 }

--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -1,3 +1,14 @@
+export type FirebaseEnvironmentName = "local" | "development" | "production";
+
+const environmentName = process.env.NEXT_PUBLIC_FIREBASE_ENVIRONMENT;
+
+export const firebaseEnvironmentName: FirebaseEnvironmentName | null =
+  environmentName === "local" ||
+  environmentName === "development" ||
+  environmentName === "production"
+    ? environmentName
+    : null;
+
 export const firebaseEnvironment = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -6,5 +17,13 @@ export const firebaseEnvironment = {
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
+
+export const firestoreEmulator = {
+  host: process.env.NEXT_PUBLIC_FIRESTORE_EMULATOR_HOST ?? "127.0.0.1",
+  port: Number(process.env.NEXT_PUBLIC_FIRESTORE_EMULATOR_PORT ?? "8080"),
+};
+
 export const isFirebaseConfigured =
-  Object.values(firebaseEnvironment).every(Boolean);
+  firebaseEnvironmentName === "local" ||
+  (firebaseEnvironmentName !== null &&
+    Object.values(firebaseEnvironment).every(Boolean));

--- a/src/lib/firebase/team-document.test.ts
+++ b/src/lib/firebase/team-document.test.ts
@@ -1,0 +1,40 @@
+import { Timestamp } from "firebase/firestore";
+import { describe, expect, it } from "vitest";
+
+import type { Team } from "@/domain/models";
+
+import { teamFromDocument, teamToDocument } from "./team-document";
+
+const team: Team = {
+  id: "test-team",
+  displayName: "Test Football Club",
+  shortName: "Test FC",
+  countryCode: "CR",
+  brandingKey: "test-fc",
+  createdAt: "2026-01-02T03:04:05.000Z",
+  updatedAt: "2026-02-03T04:05:06.000Z",
+};
+
+describe("Team Firestore conversion", () => {
+  it("round-trips a Team without leaking Firestore timestamps", () => {
+    expect(teamFromDocument(team.id, teamToDocument(team))).toEqual(team);
+  });
+
+  it("preserves an optional external provider ID", () => {
+    const mapped = { ...team, externalProviderId: "provider-42" };
+    expect(teamFromDocument(mapped.id, teamToDocument(mapped))).toEqual(mapped);
+  });
+
+  it("fails clearly for malformed persisted data", () => {
+    expect(() =>
+      teamFromDocument("broken", {
+        displayName: "Broken FC",
+        shortName: "Broken",
+        countryCode: "CR",
+        brandingKey: "broken",
+        createdAt: "not-a-timestamp",
+        updatedAt: Timestamp.now(),
+      }),
+    ).toThrow("createdAt must be a Timestamp");
+  });
+});

--- a/src/lib/firebase/team-document.ts
+++ b/src/lib/firebase/team-document.ts
@@ -1,0 +1,79 @@
+import { Timestamp } from "firebase/firestore";
+
+import type { Team } from "@/domain/models";
+
+export interface TeamDocument {
+  displayName: string;
+  shortName: string;
+  countryCode: string;
+  brandingKey: string;
+  externalProviderId?: string;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireString(data: Record<string, unknown>, field: string): string {
+  const value = data[field];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(
+      `Invalid Team document: ${field} must be a non-empty string.`,
+    );
+  }
+  return value;
+}
+
+function requireTimestamp(
+  data: Record<string, unknown>,
+  field: string,
+): Timestamp {
+  const value = data[field];
+  if (!(value instanceof Timestamp)) {
+    throw new Error(`Invalid Team document: ${field} must be a Timestamp.`);
+  }
+  return value;
+}
+
+export function teamFromDocument(id: string, value: unknown): Team {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Team document: expected an object.");
+  }
+
+  const externalProviderId = value.externalProviderId;
+  if (
+    externalProviderId !== undefined &&
+    (typeof externalProviderId !== "string" || externalProviderId.trim() === "")
+  ) {
+    throw new Error(
+      "Invalid Team document: externalProviderId must be a non-empty string when present.",
+    );
+  }
+
+  return {
+    id,
+    displayName: requireString(value, "displayName"),
+    shortName: requireString(value, "shortName"),
+    countryCode: requireString(value, "countryCode"),
+    brandingKey: requireString(value, "brandingKey"),
+    ...(externalProviderId === undefined ? {} : { externalProviderId }),
+    createdAt: requireTimestamp(value, "createdAt").toDate().toISOString(),
+    updatedAt: requireTimestamp(value, "updatedAt").toDate().toISOString(),
+  };
+}
+
+export function teamToDocument(team: Team): TeamDocument {
+  return {
+    displayName: team.displayName,
+    shortName: team.shortName,
+    countryCode: team.countryCode,
+    brandingKey: team.brandingKey,
+    ...(team.externalProviderId === undefined
+      ? {}
+      : { externalProviderId: team.externalProviderId }),
+    createdAt: Timestamp.fromDate(new Date(team.createdAt)),
+    updatedAt: Timestamp.fromDate(new Date(team.updatedAt)),
+  };
+}

--- a/src/lib/firebase/teams.ts
+++ b/src/lib/firebase/teams.ts
@@ -1,0 +1,20 @@
+import { doc, getDoc, type Firestore } from "firebase/firestore";
+
+import type { Team } from "@/domain/models";
+import { initialClub } from "@/config/club";
+
+import { teamFromDocument } from "./team-document";
+
+export async function getTeamById(
+  database: Firestore,
+  teamId: string,
+): Promise<Team | null> {
+  const snapshot = await getDoc(doc(database, "teams", teamId));
+  return snapshot.exists()
+    ? teamFromDocument(snapshot.id, snapshot.data())
+    : null;
+}
+
+export function getInitialTeam(database: Firestore): Promise<Team | null> {
+  return getTeamById(database, initialClub.teamId);
+}

--- a/tests/firebase/teams.rules.test.ts
+++ b/tests/firebase/teams.rules.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs";
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import { deleteApp, initializeApp } from "firebase/app";
+import { connectFirestoreEmulator, getFirestore } from "firebase/firestore";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getTeamById } from "@/lib/firebase/teams";
+
+import { ensureDevelopmentTeam } from "../../scripts/seed-development.mjs";
+
+const projectId = process.env.GCLOUD_PROJECT ?? "demo-rating-app-local";
+let environment: RulesTestEnvironment;
+let emulatorHost: string;
+let emulatorPort: number;
+
+beforeAll(async () => {
+  const hostAndPort = process.env.FIRESTORE_EMULATOR_HOST;
+  if (!hostAndPort) throw new Error("FIRESTORE_EMULATOR_HOST is required.");
+  const [host, port] = hostAndPort.split(":");
+  if (!host || !port) throw new Error("Invalid FIRESTORE_EMULATOR_HOST.");
+  emulatorHost = host;
+  emulatorPort = Number(port);
+  environment = await initializeTestEnvironment({
+    projectId,
+    firestore: {
+      host: emulatorHost,
+      port: emulatorPort,
+      rules: readFileSync("firestore.rules", "utf8"),
+    },
+  });
+});
+
+beforeEach(async () => environment.clearFirestore());
+afterAll(async () => environment.cleanup());
+
+describe("Team persistence and rules", () => {
+  it("seeds the deterministic initial Team idempotently", async () => {
+    const first = await ensureDevelopmentTeam({
+      emulatorHost: process.env.FIRESTORE_EMULATOR_HOST,
+      projectId,
+    });
+    let firstData: unknown;
+    await environment.withSecurityRulesDisabled(async (context) => {
+      firstData = (
+        await context.firestore().doc(`teams/${first.teamId}`).get()
+      ).data();
+    });
+
+    const second = await ensureDevelopmentTeam({
+      emulatorHost: process.env.FIRESTORE_EMULATOR_HOST,
+      projectId,
+    });
+    let secondData: unknown;
+    await environment.withSecurityRulesDisabled(async (context) => {
+      secondData = (
+        await context.firestore().doc(`teams/${second.teamId}`).get()
+      ).data();
+    });
+
+    expect(first).toEqual({ created: true, teamId: "club-sport-herediano" });
+    expect(second).toEqual({ created: false, teamId: first.teamId });
+    expect(secondData).toEqual(firstData);
+  });
+
+  it("allows public Team reads through the typed persistence boundary", async () => {
+    await ensureDevelopmentTeam({
+      emulatorHost: process.env.FIRESTORE_EMULATOR_HOST,
+      projectId,
+    });
+    const app = initializeApp({ projectId }, `public-reader-${Date.now()}`);
+    const database = getFirestore(app);
+    connectFirestoreEmulator(database, emulatorHost, emulatorPort);
+    const team = await getTeamById(database, "club-sport-herediano");
+    await deleteApp(app);
+
+    expect(team).toMatchObject({
+      id: "club-sport-herediano",
+      displayName: "Club Sport Herediano",
+      shortName: "Herediano",
+      countryCode: "CR",
+      brandingKey: "herediano",
+    });
+  });
+
+  it("rejects arbitrary Team writes from unauthenticated and authenticated clients", async () => {
+    const unauthenticated = environment.unauthenticatedContext().firestore();
+    const authenticated = environment
+      .authenticatedContext("supporter-1")
+      .firestore();
+    const arbitraryTeam = { displayName: "Arbitrary Team" };
+
+    await assertFails(
+      unauthenticated.doc("teams/arbitrary").set(arbitraryTeam),
+    );
+    await assertFails(authenticated.doc("teams/arbitrary").set(arbitraryTeam));
+  });
+
+  it("rejects Team deletion while allowing an intentional public read", async () => {
+    await ensureDevelopmentTeam({
+      emulatorHost: process.env.FIRESTORE_EMULATOR_HOST,
+      projectId,
+    });
+    const reference = environment
+      .unauthenticatedContext()
+      .firestore()
+      .doc("teams/club-sport-herediano");
+    const authenticatedReference = environment
+      .authenticatedContext("supporter-1")
+      .firestore()
+      .doc("teams/club-sport-herediano");
+
+    await assertSucceeds(reference.get());
+    await assertFails(
+      authenticatedReference.set({ displayName: "Changed" }, { merge: true }),
+    );
+    await assertFails(reference.delete());
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import { fileURLToPath } from "node:url";
 export default defineConfig({
@@ -8,5 +8,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     globals: true,
+    exclude: [...configDefaults.exclude, "tests/firebase/**"],
   },
 });

--- a/vitest.firebase.config.mts
+++ b/vitest.firebase.config.mts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/firebase/**/*.test.ts"],
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary

- add explicit local/development/production Firebase environment selection
- persist Club Sport Herediano as the deterministic `teams/club-sport-herediano` Team
- add validated Firestore serialization and focused Team read operations
- add an idempotent, emulator-only development bootstrap

## Architecture

- keeps browser Firebase and the inactive privileged server boundary separate
- uses a canonical seed record for Team identity/name while theme colors remain presentation configuration
- connects local browser Firestore to the emulator exactly once and never falls back to cloud
- does not add Firebase Admin or a generic repository framework

## Security

- permits intentional public reads of `teams/{teamId}`
- denies all client Team creates, updates, and deletes
- leaves every other collection deny-all
- restricts bootstrap writes to local emulator hosts and `demo-*` project IDs

## Testing

- unit tests cover Team conversion, malformed data, and seed safety guards
- emulator tests cover deterministic/idempotent bootstrap and the typed read boundary
- rules tests verify public reads and denied unauthenticated/authenticated writes, updates, and deletes

## Verification

- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (8 tests)
- `npm run test:firebase` (4 emulator tests)
- `npm run build`
- `npm run verify`
- `git diff --check`

All passed locally.

## Manual setup

- install Java 21+
- install Firebase CLI 15.28.2 externally
- copy `.env.example` to `.env.local`
- run `npm run firebase:emulators`, then `npm run seed:firebase`

No production Firebase project or credentials are required.

## Deferred

API-Football, competitions, seasons, matches, players, coaches, authentication UX, voting, aggregates, history, cloud Team administration, and Firebase Admin remain intentionally deferred.