### PR TITLE
chore: unify local development startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Typed, build-time message resources live in `src/i18n/messages`. Every visible p
 
 ## Developer workflow
 
-Requirements: Node.js 22 and npm. CI uses the same Node major version.
+Requirements: Node.js 22, npm, Java 21, and the globally installed Firebase CLI 15.28.2. CI uses the same Node major version and pins the same Firebase CLI version.
 
 ```bash
 npm ci
@@ -22,12 +22,14 @@ copy .env.example .env.local
 npm run dev
 ```
 
-The page works without Firebase values and will not contact a Firebase project. `.env.example` is committed, `.env.local` is ignored and developer-owned, and CI variables must be supplied by CI configuration when a future test needs them.
+With the template's `NEXT_PUBLIC_FIREBASE_ENVIRONMENT=local`, `npm run dev` starts Next.js, the Firebase Auth and Firestore emulators, and the Emulator UI together. Local browser Firebase calls connect only to those emulators and never fall back to a cloud project. `.env.example` is committed, `.env.local` is ignored and developer-owned, and CI variables must be supplied by CI configuration when a future test needs them.
 
 Common commands:
 
 ```bash
-npm run dev           # local Next.js server
+npm run dev           # Next.js plus Auth/Firestore emulators and Emulator UI
+npm run dev:web       # Next.js only; advanced/focused web development
+npm run firebase:emulators # Auth/Firestore emulators without Next.js
 npm run format        # write Prettier formatting
 npm run format:check  # check formatting only
 npm run lint          # ESLint
@@ -50,13 +52,13 @@ Firebase environments are explicit:
 - `development` requires a complete Firebase Web configuration for a separate cloud development project.
 - `production` requires a complete production Web configuration and must never be used for local seeding or tests.
 
-For local persistence work, install Java and Firebase CLI 15.28.2 separately, copy `.env.example` to `.env.local`, and run:
+For local work, install Java 21 and Firebase CLI 15.28.2 separately, copy `.env.example` to `.env.local`, and run the normal one-command startup:
 
 ```bash
-npm run firebase:emulators
+npm run dev
 ```
 
-Auth runs on 9099, Firestore on 8080, and the Emulator UI on 4000. In another terminal, explicitly bootstrap the deterministic initial Team:
+Next.js normally runs on 3000, Auth on 9099, Firestore on 8080, and the Emulator UI on 4000. Stopping the parent command stops both the web and Firebase child processes. Use `npm run dev:web` only when Firebase is already running elsewhere or the web process must be isolated; use `npm run firebase:emulators` to run only the emulators. In another terminal, explicitly bootstrap the deterministic initial Team when persistence data is needed:
 
 ```bash
 npm run seed:firebase
@@ -66,7 +68,7 @@ The bootstrap targets Firestore at `127.0.0.1:8080` by default, accepts only a l
 
 ## Voter identity
 
-The browser quietly ensures a Firebase anonymous user on first visit. Firebase UID is the canonical `voterId`, Firebase's native persistence reuses it on normal reloads, and no `voters/{uid}` document, login screen, logout/reset control, or raw UID display is created. Concurrent initialization calls share one sign-in attempt. In local mode Auth must use the emulator; malformed hosted configuration fails instead of falling back to cloud behavior.
+The browser quietly ensures a Firebase anonymous user on first visit. Firebase UID is the canonical `voterId`, Firebase's native persistence reuses it on normal reloads, and no `voters/{uid}` document, login screen, logout/reset control, or raw UID display is created. Concurrent initialization calls share one sign-in attempt. React Strict Mode may restart the initializer effect during development; cleanup suppresses the superseded effect's duplicate failure log without disabling Strict Mode or changing sign-in deduplication. In local/development mode, voter-session failures log only the mapped category and an allowlisted Firebase `auth/*` or `app/*` cause code. Production retains the generic message, and neither path logs tokens, UIDs, credentials, or raw error messages. In local mode Auth must use the emulator; malformed hosted configuration fails instead of falling back to cloud behavior.
 
 Anonymous authentication identifies a browser profile, not a person. Clearing storage, incognito, another browser/device, or another anonymous account can produce a different UID. Rating App does not use fingerprinting. Future provider linking may upgrade the same Firebase account while preserving its UID where Firebase supports it; automatic anonymous-account cleanup is not assumed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.1.1",
+        "concurrently": "^10.0.5",
         "eslint": "^9.39.5",
         "eslint-config-next": "16.3.3",
         "eslint-config-prettier": "^10.1.8",
@@ -5184,6 +5185,185 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concurrently": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.5.tgz",
+      "integrity": "sha512-JaP/CoftUrCcAFW/g//RbgEGwlelnEae6cfBLgH6ZdO6s8jPkn6p9SB9u6pdVxYXoiSnFqseOlHfrEfF82TVOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.9.0",
+        "supports-color": "10.2.2",
+        "tree-kill": "1.2.2",
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/concurrently/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -6761,6 +6941,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -9573,6 +9766,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
@@ -9810,6 +10013,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -10439,6 +10655,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "node": ">=22 <23"
   },
   "scripts": {
-    "dev": "next dev",
+    "dev": "concurrently --kill-others --names web,firebase --prefix-colors cyan,magenta \"npm:dev:web\" \"npm:firebase:emulators\"",
+    "dev:web": "next dev",
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",
@@ -41,6 +42,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.1.1",
+    "concurrently": "^10.0.5",
     "eslint": "^9.39.5",
     "eslint-config-next": "16.3.3",
     "eslint-config-prettier": "^10.1.8",

--- a/scripts/development-scripts.test.mts
+++ b/scripts/development-scripts.test.mts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+  scripts: Record<string, string>;
+  devDependencies: Record<string, string>;
+};
+
+describe("local development scripts", () => {
+  it("supervises the web app and Firebase emulators from the default command", () => {
+    expect(packageJson.scripts.dev).toContain("concurrently --kill-others");
+    expect(packageJson.scripts.dev).toContain("npm:dev:web");
+    expect(packageJson.scripts.dev).toContain("npm:firebase:emulators");
+    expect(packageJson.devDependencies.concurrently).toMatch(/^\^10\./);
+  });
+
+  it("preserves focused web and emulator commands", () => {
+    expect(packageJson.scripts["dev:web"]).toBe("next dev");
+    expect(packageJson.scripts["firebase:emulators"]).toBe(
+      "firebase emulators:start --only auth,firestore",
+    );
+  });
+});

--- a/src/components/voter-identity-initializer.test.tsx
+++ b/src/components/voter-identity-initializer.test.tsx
@@ -1,0 +1,40 @@
+import { StrictMode } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureAnonymousVoter: vi.fn(),
+  reportVoterIdentityFailure: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/voter-auth", () => ({
+  ensureAnonymousVoter: mocks.ensureAnonymousVoter,
+}));
+vi.mock("@/lib/firebase/voter-identity-diagnostics", () => ({
+  reportVoterIdentityFailure: mocks.reportVoterIdentityFailure,
+}));
+
+import { VoterIdentityInitializer } from "./voter-identity-initializer";
+
+describe("VoterIdentityInitializer", () => {
+  it("logs one failure when Strict Mode supersedes its first effect", async () => {
+    let rejectAttempt: ((error: Error) => void) | undefined;
+    const attempt = new Promise<never>((_resolve, reject) => {
+      rejectAttempt = reject;
+    });
+    mocks.ensureAnonymousVoter.mockReturnValue(attempt);
+
+    render(
+      <StrictMode>
+        <VoterIdentityInitializer />
+      </StrictMode>,
+    );
+    const error = new Error("auth failed");
+    rejectAttempt?.(error);
+
+    await waitFor(() =>
+      expect(mocks.reportVoterIdentityFailure).toHaveBeenCalledOnce(),
+    );
+    expect(mocks.reportVoterIdentityFailure).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/components/voter-identity-initializer.tsx
+++ b/src/components/voter-identity-initializer.tsx
@@ -2,13 +2,18 @@
 
 import { useEffect } from "react";
 
+import { reportVoterIdentityFailure } from "@/lib/firebase/voter-identity-diagnostics";
 import { ensureAnonymousVoter } from "@/lib/firebase/voter-auth";
 
 export function VoterIdentityInitializer() {
   useEffect(() => {
-    void ensureAnonymousVoter().catch(() => {
-      console.error("Unable to prepare the voter session.");
+    let active = true;
+    void ensureAnonymousVoter().catch((error: unknown) => {
+      if (active) reportVoterIdentityFailure(error);
     });
+    return () => {
+      active = false;
+    };
   }, []);
 
   return null;

--- a/src/lib/firebase/voter-auth.test.ts
+++ b/src/lib/firebase/voter-auth.test.ts
@@ -67,7 +67,9 @@ describe("ensureAnonymousVoter", () => {
 
   it.each([
     ["auth/network-request-failed", "unavailable"],
+    ["auth/internal-error", "unavailable"],
     ["auth/operation-not-allowed", "disabled"],
+    ["auth/invalid-api-key", "unknown"],
   ])("maps %s without exposing its raw message", async (firebaseCode, code) => {
     getBrowserAuth.mockReturnValue({
       authStateReady: vi.fn().mockResolvedValue(undefined),
@@ -84,5 +86,18 @@ describe("ensureAnonymousVoter", () => {
     expect(error).toMatchObject({ code });
     expect(error.message).toBe("Unable to prepare voter identity.");
     expect(error.message).not.toContain("sensitive");
+  });
+
+  it("maps browser configuration failures without exposing details", async () => {
+    getBrowserAuth.mockImplementation(() => {
+      throw new Error("FIREBASE_ADMIN_PRIVATE_KEY=must-not-leak");
+    });
+    const { ensureAnonymousVoter, VoterIdentityError } =
+      await import("./voter-auth");
+
+    const error = await ensureAnonymousVoter().catch((caught) => caught);
+    expect(error).toBeInstanceOf(VoterIdentityError);
+    expect(error).toMatchObject({ code: "configuration" });
+    expect(error.message).not.toContain("PRIVATE_KEY");
   });
 });

--- a/src/lib/firebase/voter-identity-diagnostics.test.ts
+++ b/src/lib/firebase/voter-identity-diagnostics.test.ts
@@ -1,0 +1,62 @@
+import { FirebaseError } from "firebase/app";
+import { describe, expect, it, vi } from "vitest";
+
+import { reportVoterIdentityFailure } from "./voter-identity-diagnostics";
+import { VoterIdentityError } from "./voter-auth";
+
+describe("reportVoterIdentityFailure", () => {
+  it.each(["local", "development"] as const)(
+    "logs a safe mapped category and Firebase code in %s",
+    (environment) => {
+      const logger = vi.fn();
+      reportVoterIdentityFailure(
+        new VoterIdentityError("unavailable", {
+          cause: new FirebaseError(
+            "auth/network-request-failed",
+            "sensitive network detail",
+          ),
+        }),
+        { environment, nodeEnvironment: "development", logger },
+      );
+
+      expect(logger).toHaveBeenCalledWith(
+        "Unable to prepare the voter session.",
+        {
+          code: "unavailable",
+          causeCode: "auth/network-request-failed",
+        },
+      );
+      expect(JSON.stringify(logger.mock.calls)).not.toContain("sensitive");
+    },
+  );
+
+  it("keeps production diagnostics generic", () => {
+    const logger = vi.fn();
+    reportVoterIdentityFailure(
+      new VoterIdentityError("disabled", {
+        cause: new Error("private configuration detail"),
+      }),
+      { environment: "production", nodeEnvironment: "production", logger },
+    );
+
+    expect(logger).toHaveBeenCalledWith("Unable to prepare the voter session.");
+    expect(JSON.stringify(logger.mock.calls)).not.toContain("private");
+    expect(JSON.stringify(logger.mock.calls)).not.toContain("disabled");
+  });
+
+  it("does not copy arbitrary cause codes into diagnostics", () => {
+    const logger = vi.fn();
+    reportVoterIdentityFailure(
+      new VoterIdentityError("configuration", {
+        cause: { code: "secret/private-key", token: "do-not-log" },
+      }),
+      { environment: "local", nodeEnvironment: "development", logger },
+    );
+
+    expect(logger).toHaveBeenCalledWith(
+      "Unable to prepare the voter session.",
+      { code: "configuration" },
+    );
+    expect(JSON.stringify(logger.mock.calls)).not.toContain("do-not-log");
+  });
+});

--- a/src/lib/firebase/voter-identity-diagnostics.ts
+++ b/src/lib/firebase/voter-identity-diagnostics.ts
@@ -1,0 +1,46 @@
+import { firebaseEnvironmentName } from "./config";
+import { VoterIdentityError } from "./voter-auth";
+
+type DiagnosticEnvironment = "local" | "development" | "production" | null;
+
+export function reportVoterIdentityFailure(
+  error: unknown,
+  options: {
+    environment?: DiagnosticEnvironment;
+    nodeEnvironment?: string;
+    logger?: (message: string, details?: object) => void;
+  } = {},
+): void {
+  const environment = options.environment ?? firebaseEnvironmentName;
+  const nodeEnvironment = options.nodeEnvironment ?? process.env.NODE_ENV;
+  const logger = options.logger ?? console.error;
+
+  if (environment === "production" || nodeEnvironment === "production") {
+    logger("Unable to prepare the voter session.");
+    return;
+  }
+
+  logger("Unable to prepare the voter session.", safeDiagnostic(error));
+}
+
+function safeDiagnostic(error: unknown): {
+  code: "configuration" | "disabled" | "unavailable" | "unknown";
+  causeCode?: string;
+} {
+  if (!(error instanceof VoterIdentityError)) return { code: "unknown" };
+  const causeCode = readSafeCauseCode(error.cause);
+  return {
+    code: error.code,
+    ...(causeCode === undefined ? {} : { causeCode }),
+  };
+}
+
+function readSafeCauseCode(cause: unknown): string | undefined {
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return undefined;
+  }
+  const code = cause.code;
+  return typeof code === "string" && /^(auth|app)\/[a-z0-9-]+$/.test(code)
+    ? code
+    : undefined;
+}


### PR DESCRIPTION
## Summary

Make local development a one-command workflow: `npm run dev` now supervises Next.js and the Firebase Auth/Firestore emulators together, including clean sibling termination when a required child exits.

## Commands

- `npm run dev` starts Next.js, Auth on 9099, Firestore on 8080, and Emulator UI on 4000
- `npm run dev:web` starts only Next.js for focused/advanced use
- `npm run firebase:emulators` continues to start the Firebase emulators independently

The globally installed Firebase CLI 15.28.2 and Java 21 remain external prerequisites; `firebase-tools` was not added to application dependencies.

## Auth diagnostics

Local/development voter-session failures now log the mapped `VoterIdentityError` category and only an allowlisted Firebase `auth/*` or `app/*` cause code. Production keeps the generic sanitized message. Raw causes, messages, tokens, UIDs, user objects, and credentials are never logged. Effect cleanup suppresses the superseded React Strict Mode failure handler while preserving the existing shared anonymous-sign-in attempt.

## Verification

- `npm ci` — passed
- `npm run verify` — passed (format, lint, typecheck, 103 tests, production build)
- `npm run test:firebase` — passed (35 emulator tests)
- `git diff --check` — passed
- `npm audit --audit-level=moderate` — reviewed; eight existing moderate transitive `uuid` findings remain because the offered fix forces a breaking Firebase Admin downgrade
- manual `npm run dev` — Next.js, Auth, Firestore, and Emulator UI started; web/UI returned 200; anonymous identity initialized and the same UID was reused after reload; zero voter-session errors; Ctrl+C closed ports 3000/4000/8080/9099
- manual `npm run dev:web` — only Next.js port 3000 started
- failure supervision — a deliberate occupied-port startup failure terminated the Firebase sibling process

## Scope

No product, ballot, lifecycle, schema, security-rule, or visible UI behavior changed. No deployment was performed.
