### PR TITLE
chore: prepare production pilot release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 # COMMITTED TEMPLATE: copy to .env.local for local development.
 # LOCAL ONLY: .env.local is ignored by Git. CI values must come from CI secrets.
 #
-# Public Firebase web configuration. NEXT_PUBLIC_ values are included in the
-# browser bundle by Next.js; authorization must be enforced by Firebase rules.
+# Runtime mode: local, development, or production. Hosted deployments require
+# every public Web value below; production rejects demo-* project IDs.
+# NEXT_PUBLIC_ values are browser-visible and are not secrets.
 NEXT_PUBLIC_FIREBASE_ENVIRONMENT=local
 NEXT_PUBLIC_FIREBASE_API_KEY=
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
@@ -11,20 +12,25 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 NEXT_PUBLIC_FIREBASE_APP_ID=
 
-# Local mode always connects Firestore and Auth to these endpoints and never
-# falls back to a cloud project. Hosted modes require complete web config.
+# LOCAL ONLY: browser emulator endpoints. Local trusted server code derives its
+# Admin emulator endpoints from these values unless Firebase CLI/tests supply
+# the standard host variables explicitly.
 NEXT_PUBLIC_FIRESTORE_EMULATOR_HOST=127.0.0.1
 NEXT_PUBLIC_FIRESTORE_EMULATOR_PORT=8080
 NEXT_PUBLIC_AUTH_EMULATOR_HOST=127.0.0.1
 NEXT_PUBLIC_AUTH_EMULATOR_PORT=9099
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
+FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+GCLOUD_PROJECT=demo-rating-app-local
 
 # SERVER/ADMIN ONLY: never prefix this secret with NEXT_PUBLIC_. The explicit
 # football sync command reads it locally; CI uses provider fixtures instead.
 API_FOOTBALL_KEY=
 
-# SERVER/ADMIN ONLY: protects the internal lifecycle endpoint.
+# SERVER/ADMIN ONLY: required in hosted development/production. Local mode uses
+# the demo project/emulators and does not require Admin credentials.
 CRON_SECRET=
 FIREBASE_ADMIN_PROJECT_ID=
 FIREBASE_ADMIN_CLIENT_EMAIL=
-# Use an escaped multiline value (-----BEGIN...\\n...-----END...).
+# Use escaped newlines: -----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n
 FIREBASE_ADMIN_PRIVATE_KEY=

--- a/.github/workflows/match-lifecycle.yml
+++ b/.github/workflows/match-lifecycle.yml
@@ -23,8 +23,9 @@ jobs:
         if: env.LIFECYCLE_SYNC_URL != '' && env.CRON_SECRET != ''
         run: >-
           curl --fail --silent --show-error
-          --retry 2 --retry-all-errors
-          --max-time 90
+          --connect-timeout 10
+          --retry 1 --retry-all-errors --retry-max-time 100
+          --max-time 45
           --request POST
           --header "Authorization: Bearer ${CRON_SECRET}"
           "${LIFECYCLE_SYNC_URL}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@ Before product-code changes, read this file completely along with `PRODUCT.md`, 
 - Do not edit or commit generated output such as `.next`, coverage, emulator data, `next-env.d.ts`, or TypeScript build-info files.
 - Use `npm run verify` as the complete local quality gate: formatting, lint, strict typecheck, all tests, and production build. Also run `git diff --check` before handoff. Wait for every process to exit and never report a command as passing while it is still running.
 - Keep Git changes scoped and preserve unrelated user work. CI must use `npm ci` and invoke the same canonical verification command without production credentials.
+- Production must never use demo projects or emulator hosts. Keep local seed/sync commands emulator-only; production mutations require an explicit trusted path, exact project confirmation, and the complete verification gate.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ matches/{matchId}
 matches/{matchId}/participants/{playerId}
 matches/{matchId}/coachAssignments/{coachId}
 matches/{matchId}/ballots/{voterId}
-matches/{matchId}/aggregates/summary
+matches/{matchId}/results/summary
 players/{playerId}/matchSummaries/{matchId}
 players/{playerId}/statistics/{seasonOrCareerId}
 ```
@@ -96,3 +96,9 @@ Every match references a tracked `teamId`; community and theme configuration sel
 ## Deployment and cost
 
 Deploy the Next.js app to a platform compatible with its server runtime (initially Vercel is suitable) and use Firebase Auth/Firestore free tiers. Prefer static/server rendering, cached provider imports, compact ballot documents, materialized aggregates, and bounded reads. Cloud Functions and scheduled imports are deferred until needed; monitor quotas before opening beyond the initial group.
+
+Hosted runtime configuration is validated centrally before Firebase Admin use. Development and production reject emulator hosts, demo projects, mismatched Web/Admin project IDs, missing credentials, and malformed private keys. Local trusted reads derive Auth/Firestore emulator hosts from explicit local configuration, so unified development cannot silently reach cloud Firebase. Home, ballot, and result routes are force-dynamic with zero revalidation; ballot and lifecycle responses are explicitly `no-store`.
+
+Production begins with one separately guarded, idempotent Team bootstrap that requires production mode, an exact non-demo project confirmation, the stable provider Team ID, and Firebase Admin credentials. Existing emulator seed/sync scripts remain incapable of hosted writes. Once the Team exists, the authenticated lifecycle endpoint uses the normal bounded discovery path to create competition, season, and fixture state. The authenticated read-only `/api/internal/health` endpoint verifies runtime configuration and the canonical Team read without exposing configuration values.
+
+No production environment or deployment is currently configured. `PRODUCTION_RUNBOOK.md` is the operational source for controlled pilot setup, verification, scheduler activation, rollback, and secret rotation.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -12,6 +12,8 @@ At trusted close time, the same lifecycle creates one immutable aggregate summar
 
 Not implemented now: cloud Team administration, identity-provider linking, history/archive pages, season leaderboards, notifications, or administration. Individual ballot data remains private at all times, and aggregates remain unavailable before close.
 
+The codebase includes guarded production configuration and bootstrap boundaries for a controlled pilot, but no production Firebase or Vercel environment has been configured or deployed.
+
 ## MVP
 
 After a match finishes, voting opens for approximately two hours. An authenticated supporter sees every Herediano player who actually played—not unused squad members—and the match's head coach. They submit one complete ballot. Aggregate results remain hidden until voting closes.

--- a/PRODUCTION_RUNBOOK.md
+++ b/PRODUCTION_RUNBOOK.md
@@ -1,0 +1,126 @@
+# Production pilot runbook
+
+Rating App is prepared for a controlled Vercel + Firebase production pilot. This is an execution checklist, not evidence of deployment. No production environment is currently configured.
+
+## Architecture and prerequisites
+
+The browser loads the Node.js 22 Next.js app from Vercel and uses Firebase Authentication directly for persistent anonymous identity. Server-rendered pages and trusted endpoints use Firebase Admin with Cloud Firestore. API-Football Pro is called only by the lifecycle service. A private GitHub Actions workflow sends a credentialed request to the deployed lifecycle endpoint every 30 minutes; it performs no checkout or dependency installation.
+
+Prepare Node.js 22, Firebase CLI 15.28.2, a production Firebase project, a Firebase Web app, a narrowly held Admin service-account key, a Vercel project, an API-Football Pro key with current quota, and repository-admin access. Use an exact production project ID that does not start with `demo-`.
+
+## Canonical environment inventory
+
+### Vercel browser-visible values
+
+- `NEXT_PUBLIC_FIREBASE_ENVIRONMENT=production`
+- `NEXT_PUBLIC_FIREBASE_API_KEY`
+- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
+- `NEXT_PUBLIC_FIREBASE_PROJECT_ID`
+- `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET`
+- `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`
+- `NEXT_PUBLIC_FIREBASE_APP_ID`
+
+### Vercel server-only values
+
+- `API_FOOTBALL_KEY`
+- `CRON_SECRET`
+- `FIREBASE_ADMIN_PROJECT_ID` (must equal the public project ID)
+- `FIREBASE_ADMIN_CLIENT_EMAIL`
+- `FIREBASE_ADMIN_PRIVATE_KEY` (escaped `\n` newlines)
+
+Never configure `FIRESTORE_EMULATOR_HOST`, `FIREBASE_AUTH_EMULATOR_HOST`, `GCLOUD_PROJECT`, or public emulator host/port variables in Vercel production. Hosted runtime validation rejects emulator hosts and demo projects.
+
+### GitHub repository secrets
+
+- `LIFECYCLE_SYNC_URL`: full production `/api/internal/match-lifecycle` URL
+- `CRON_SECRET`: exactly the same value as Vercel
+
+No Firebase or API-Football credential belongs in GitHub for this workflow.
+
+### Local-only variables and commands
+
+`.env.example` documents browser emulator hosts plus `FIRESTORE_EMULATOR_HOST`, `FIREBASE_AUTH_EMULATOR_HOST`, and `GCLOUD_PROJECT`. Local mode permits only a `demo-*` Admin project. `seed:firebase`, `sync:football`, `sync:match-participants`, and `sync:lifecycle` remain emulator-only and must never be used for production.
+
+## Firebase production checklist
+
+1. Create Cloud Firestore in the intended production region.
+2. Enable Firebase Anonymous Authentication.
+3. Add the Vercel production domain and any custom domain to Firebase Authentication authorized domains.
+4. Register the production Web app and capture its public configuration.
+5. Create a dedicated Admin service-account key; store its fields only in Vercel secrets.
+6. From a clean reviewed commit, deploy with an explicit target: `firebase deploy --only firestore:rules,firestore:indexes --project <exact-production-project-id>`. Never rely on `.firebaserc`, whose default remains the safe demo project.
+7. Verify rules: only `teams/{teamId}` is public-readable; all client writes and all other reads, including ballots and results, are denied.
+
+Current server queries need only automatic single-field indexes; `firestore.indexes.json` intentionally contains no composites. Reassess after query changes.
+
+## Safe deployment and bootstrap order
+
+1. Complete the Firebase checklist.
+2. Configure all Vercel public and server-only variables for Production only.
+3. Confirm Vercel uses Node.js 22, then deploy the reviewed commit.
+4. Confirm the public shell loads and Anonymous Auth succeeds; do not submit a ballot.
+5. Call `GET /api/internal/health` with `Authorization: Bearer <CRON_SECRET>`. Before Team bootstrap, `not_ready` is expected; unauthorized calls must return 401.
+6. From a controlled operator environment with the production variables loaded, confirm the API-Football provider Team ID independently, then run:
+
+   `npm run bootstrap:production-team -- --project-id <exact-production-project-id> --provider-team-id <confirmed-id> --confirm bootstrap-production-team`
+
+   The command rejects local/development mode, emulator hosts, demo projects, project mismatches, missing confirmation, and malformed credentials. It creates only `teams/club-sport-herediano`, or adds the explicit provider mapping when the canonical identity already matches. Repetition is idempotent; conflicting existing identity aborts.
+
+7. Repeat the authenticated health request and require `{"status":"ready"}`.
+8. Manually call the authenticated lifecycle endpoint once. It uses current-season discovery to persist competitions, seasons, and relevant Herediano fixtures; no production sync script or fixture ID is needed.
+9. Inspect Firestore and Home for the next fixture. Confirm home/away identity, competition, season, kickoff, and `not_ready` state.
+10. Add the two GitHub secrets, manually dispatch `Match lifecycle trigger`, and require a successful workflow plus a safe lifecycle response.
+11. Allow the schedule to operate only after the manual dispatch and Firestore inspection pass.
+12. Share the pilot URL only after the infrastructure smoke test is complete.
+
+## Request discipline and autonomous lifecycle
+
+When no relevant future match is known, discovery is attempted at most every 12 hours. A known fixture beyond 24 hours makes no provider request; within 24 hours it refreshes at most every six hours, within two hours every 15 minutes, and live/preparing matches on each external trigger. Participant/head-coach readiness uses one focused fixture request. Active voting, finalization, and finalized results do not cause aggressive provider polling. After a result, discovery eventually imports the next fixture; active voting, live, preparing, and scheduled matches outrank historical results on Home.
+
+Network/provider validation, missing lineup/coach, Firebase write, and aggregation integrity failures remain retryable. They cannot open voting early, extend timestamps, replace ballots, publish partial results, or regress finalized state. Cancelled/abandoned matches never open or finalize ratings; postponed/suspended matches retry conservatively.
+
+## Infrastructure smoke test
+
+- App shell loads in Spanish and English with no raw error details.
+- Anonymous Auth creates and reuses an identity; no UID is visible.
+- Authenticated health returns `ready`; missing/wrong secret returns 401.
+- Firestore Team read succeeds through Admin; browser writes and protected reads fail.
+- Authenticated lifecycle returns a bounded operational response; wrong secret returns 401 and missing API key returns a sanitized 503.
+- Vercel logs show only safe action, match ID, and provider-request count. GitHub logs do not echo secrets.
+- API-Football shows a valid Pro key, current quota, and expected bounded calls.
+
+## Controlled functional test
+
+Perform only when a real match is intentionally selected for the pilot. Confirm scheduled → live → preparing → rating-ready, exact tracked-Team participants/head coach, a controlled ballot, duplicate rejection, pre-close result lock, trusted close, immutable aggregate, and public result. Do not create junk production ballots merely to test infrastructure.
+
+## Scheduler operations and cost
+
+The workflow uses `curl` only, a 10-second connect timeout, 45-second request timeout, and one bounded retry. Missing secrets skip safely; an HTTP/network failure fails the workflow. Private-repository Actions minutes and Vercel/API/Firebase quotas must be monitored, but the pilot adds no separately paid scheduler, worker, queue, or external cron service.
+
+## Rollback
+
+1. Disable `.github/workflows/match-lifecycle.yml` or remove `LIFECYCLE_SYNC_URL`/`CRON_SECRET` to stop lifecycle triggers.
+2. If lifecycle health is uncertain, keep the scheduler disabled; established voting timestamps and immutable ballots/results remain stored.
+3. Redeploy the last known-good Vercel deployment for an application regression.
+4. Do not delete ballots or finalized result summaries during rollback.
+5. Investigate with Vercel logs, GitHub workflow status, Firestore state, and API-Football quota history before re-enabling.
+
+## Secret rotation
+
+- Rotate `CRON_SECRET` in Vercel and GitHub together; keep the scheduler disabled until both match and a manual dispatch succeeds.
+- Rotate `API_FOOTBALL_KEY` in Vercel independently, then invoke lifecycle manually and verify quota/request behavior.
+- Rotate Firebase Admin by adding the new client email/private key in Vercel, verifying health, and revoking the old service-account key afterward.
+
+Never log, commit, paste into issues, or expose these values to browser variables.
+
+## Known pilot limitations
+
+- Anonymous Auth identifies a browser profile, not a person; it is not strict one-person-one-vote.
+- App Check and broader abuse controls are not enabled yet.
+- Player histories, match archives, and season leaderboards are deferred.
+- Final aggregation reads all ballots once and assumes small-community volume.
+- The GitHub schedule is approximate and consumes private-repository Actions minutes.
+
+## Dependency audit disposition
+
+`npm audit` currently reports eight moderate findings for `uuid` below 11.1.1 through Firebase Admin's `@google-cloud/firestore`/storage transport chain. The advisory concerns caller-supplied buffers in UUID v3/v5/v6; Rating App neither imports that transitive package nor calls those UUID APIs. npm offers no compatible remediation and `--force` would downgrade Firebase Admin to 10.3.0, so the forced fix is rejected. This is acceptable for the controlled pilot, not a production blocker; monitor Firebase Admin releases and apply the first compatible upstream resolution.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Mobile-first supporter ratings for football matches. The first community is Club Sport Herediano, while the domain remains club-neutral.
 
+Production is not deployed. See [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) for the controlled pilot configuration and rollout procedure.
+
 ## Foundation status
 
 The repository now includes Spanish/English localization, tracked-Team football persistence, match-aware lifecycle synchronization, a lifecycle-aware Home scoreboard, persistent low-friction voter identity through Firebase Anonymous Authentication, the match rating ballot, and public post-voting results. A trusted server route accepts exactly one complete, participant-only ballot per Firebase UID during the stable server-controlled voting window. No aggregate is exposed before trusted close time; afterward the lifecycle creates one immutable summary and Home links to `/matches/{matchId}/results`.
@@ -40,6 +42,7 @@ npm run test:firebase # Auth/Firestore emulator integration and security-rule te
 npm run sync:football # import bounded API-Football data into the emulator
 npm run sync:match-participants -- <match-id> # import one match's squad, participants, and coach
 npm run sync:lifecycle # run match-aware lifecycle logic against the emulator
+npm run bootstrap:production-team -- ... # guarded production Team bootstrap; see runbook
 npm run build         # production build
 npm run verify        # canonical complete local/CI quality gate
 ```
@@ -97,6 +100,8 @@ The internal `POST /api/internal/match-lifecycle` route reuses the same lifecycl
 - `FIREBASE_ADMIN_PRIVATE_KEY` with newlines escaped as `\\n`
 
 Do not use `NEXT_PUBLIC_` for any of them and do not commit a service-account file. Configure Firebase Admin credentials for an explicit development project before a production project. The route is stateless and Vercel-compatible; emulator tests use test doubles/local REST and never cloud credentials.
+
+An authenticated `GET /api/internal/health` performs a read-only configuration and canonical Team readiness check. It returns only `ready`, `not_ready`, or `unauthorized`, uses the same `CRON_SECRET`, never calls API-Football, and is intended for controlled deployment smoke tests.
 
 The `Match lifecycle trigger` GitHub workflow is manually dispatchable and scheduled every 30 minutes. Add repository secrets `LIFECYCLE_SYNC_URL` (the full deployed endpoint URL) and `CRON_SECRET` (the same value configured on Vercel) only after the endpoint is deployed. Until both exist, the workflow skips successfully, avoiding recurring calls to a nonexistent deployment. Each configured run is a lightweight HTTP trigger; persisted match state performs most idle early exits without an API-Football request. Fixture discovery runs at most twice daily when no upcoming match is known, focused polling increases near/live matches, and frequent polling stops once the rating window exists. This avoids new paid scheduler infrastructure but GitHub/Vercel plan usage should be monitored rather than treated as an unconditional billing guarantee.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sync:football": "tsx --env-file=.env.local scripts/sync-football.ts",
     "sync:match-participants": "tsx --env-file=.env.local scripts/sync-match-participants.ts",
     "sync:lifecycle": "tsx --env-file=.env.local scripts/sync-lifecycle.ts",
+    "bootstrap:production-team": "tsx scripts/bootstrap-production-team.ts",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build"
   },
   "dependencies": {

--- a/scripts/bootstrap-production-team.test.mts
+++ b/scripts/bootstrap-production-team.test.mts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { parseProductionBootstrapArguments } from "./bootstrap-production-team";
+
+describe("production Team bootstrap guardrails", () => {
+  it("requires explicit matching arguments and confirmation", () => {
+    expect(
+      parseProductionBootstrapArguments([
+        "--project-id",
+        "rating-app-production",
+        "--provider-team-id",
+        "815",
+        "--confirm",
+        "bootstrap-production-team",
+      ]),
+    ).toEqual({
+      projectId: "rating-app-production",
+      providerTeamId: "815",
+    });
+  });
+
+  it("rejects missing confirmation, invalid provider identity, and demo projects", () => {
+    expect(() =>
+      parseProductionBootstrapArguments([
+        "--project-id",
+        "rating-app-production",
+        "--provider-team-id",
+        "815",
+      ]),
+    ).toThrow("Usage");
+    expect(() =>
+      parseProductionBootstrapArguments([
+        "--project-id",
+        "rating-app-production",
+        "--provider-team-id",
+        "not-numeric",
+        "--confirm",
+        "bootstrap-production-team",
+      ]),
+    ).toThrow("Usage");
+    expect(() =>
+      parseProductionBootstrapArguments([
+        "--project-id",
+        "demo-rating-app-local",
+        "--provider-team-id",
+        "815",
+        "--confirm",
+        "bootstrap-production-team",
+      ]),
+    ).toThrow("demo-*");
+  });
+});

--- a/scripts/bootstrap-production-team.ts
+++ b/scripts/bootstrap-production-team.ts
@@ -1,0 +1,117 @@
+import { pathToFileURL } from "node:url";
+
+import { cert, deleteApp, initializeApp } from "firebase-admin/app";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+
+import initialTeam from "../firebase/seed/initial-team.json";
+import { readFirebaseAdminRuntimeConfig } from "../src/lib/server/environment";
+
+const CONFIRMATION = "bootstrap-production-team";
+
+export interface ProductionBootstrapArguments {
+  projectId: string;
+  providerTeamId: string;
+}
+
+export function parseProductionBootstrapArguments(
+  arguments_: readonly string[],
+): ProductionBootstrapArguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!key?.startsWith("--") || !value) throw usageError();
+    values.set(key, value);
+  }
+  const projectId = values.get("--project-id");
+  const providerTeamId = values.get("--provider-team-id");
+  if (
+    !projectId ||
+    !providerTeamId ||
+    !/^\d+$/.test(providerTeamId) ||
+    values.get("--confirm") !== CONFIRMATION ||
+    values.size !== 3
+  ) {
+    throw usageError();
+  }
+  if (projectId.startsWith("demo-")) {
+    throw new Error("Production bootstrap rejects demo-* projects.");
+  }
+  return { projectId, providerTeamId };
+}
+
+async function main() {
+  const arguments_ = parseProductionBootstrapArguments(process.argv.slice(2));
+  const config = readFirebaseAdminRuntimeConfig();
+  if (config.environment !== "production" || config.emulator) {
+    throw new Error(
+      "Team bootstrap requires production mode without emulators.",
+    );
+  }
+  if (config.projectId !== arguments_.projectId) {
+    throw new Error("The confirmed project ID does not match Firebase Admin.");
+  }
+  const app = initializeApp(
+    {
+      projectId: config.projectId,
+      credential: cert({
+        projectId: config.projectId,
+        clientEmail: config.clientEmail!,
+        privateKey: config.privateKey!,
+      }),
+    },
+    `production-team-bootstrap-${Date.now()}`,
+  );
+  try {
+    const database = getFirestore(app);
+    const reference = database.doc(`teams/${initialTeam.id}`);
+    const outcome = await database.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(reference);
+      if (snapshot.exists) {
+        const existing = snapshot.data();
+        if (
+          existing?.displayName !== initialTeam.displayName ||
+          (existing.externalProviderId !== undefined &&
+            existing.externalProviderId !== arguments_.providerTeamId)
+        ) {
+          throw new Error("Existing canonical Team identity does not match.");
+        }
+        if (existing.externalProviderId === arguments_.providerTeamId) {
+          return "unchanged" as const;
+        }
+        transaction.update(reference, {
+          externalProviderId: arguments_.providerTeamId,
+          updatedAt: Timestamp.now(),
+        });
+        return "mapped" as const;
+      }
+      const now = Timestamp.now();
+      transaction.create(reference, {
+        displayName: initialTeam.displayName,
+        shortName: initialTeam.shortName,
+        countryName: initialTeam.countryName,
+        countryCode: initialTeam.countryCode,
+        brandingKey: initialTeam.brandingKey,
+        externalProviderId: arguments_.providerTeamId,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return "created" as const;
+    });
+    console.log(
+      `Production Team bootstrap ${outcome}: teams/${initialTeam.id}.`,
+    );
+  } finally {
+    await deleteApp(app);
+  }
+}
+
+function usageError() {
+  return new Error(
+    "Usage: npm run bootstrap:production-team -- --project-id <project> --provider-team-id <id> --confirm bootstrap-production-team",
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/src/app/api/internal/health/route.test.ts
+++ b/src/app/api/internal/health/route.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ getTeam: vi.fn() }));
+vi.mock("@/lib/firebase/server", () => ({
+  AdminFootballSyncStore: class {
+    getTeam = mocks.getTeam;
+  },
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  vi.stubEnv("NEXT_PUBLIC_FIREBASE_ENVIRONMENT", "local");
+  vi.stubEnv("CRON_SECRET", "cron-secret");
+  vi.stubEnv("API_FOOTBALL_KEY", "provider-key");
+  mocks.getTeam.mockResolvedValue({ id: "club-sport-herediano" });
+});
+
+describe("GET /api/internal/health", () => {
+  it("fails closed without the scheduler credential", async () => {
+    const response = await GET(new Request("http://local/health"));
+    expect(response.status).toBe(401);
+    expect(mocks.getTeam).not.toHaveBeenCalled();
+  });
+
+  it("reports only a safe ready state", async () => {
+    const response = await GET(
+      new Request("http://local/health", {
+        headers: { Authorization: "Bearer cron-secret" },
+      }),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "ready" });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("returns a sanitized not-ready response for configuration or Firestore failures", async () => {
+    mocks.getTeam.mockRejectedValue(new Error("secret credential content"));
+    const response = await GET(
+      new Request("http://local/health", {
+        headers: { Authorization: "Bearer cron-secret" },
+      }),
+    );
+    expect(response.status).toBe(503);
+    const body = JSON.stringify(await response.json());
+    expect(body).toBe('{"status":"not_ready"}');
+    expect(body).not.toContain("credential");
+  });
+});

--- a/src/app/api/internal/health/route.ts
+++ b/src/app/api/internal/health/route.ts
@@ -1,0 +1,29 @@
+import { initialClub } from "@/config/club";
+import { AdminFootballSyncStore } from "@/lib/firebase/server";
+import { isAuthorizedCronRequest } from "@/lib/server/cron-auth";
+import { requireLifecycleRuntimeConfig } from "@/lib/server/environment";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET ?? "";
+  if (!isAuthorizedCronRequest(request.headers.get("authorization"), secret)) {
+    return json({ status: "unauthorized" }, 401);
+  }
+  try {
+    requireLifecycleRuntimeConfig();
+    await new AdminFootballSyncStore().getTeam(initialClub.teamId);
+    return json({ status: "ready" });
+  } catch {
+    console.error("Internal readiness check failed.");
+    return json({ status: "not_ready" }, 503);
+  }
+}
+
+function json(body: object, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/src/app/api/internal/match-lifecycle/route.test.ts
+++ b/src/app/api/internal/match-lifecycle/route.test.ts
@@ -1,16 +1,21 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({ run: vi.fn() }));
 vi.mock("@/application/run-lifecycle", () => ({
-  runConfiguredLifecycle: vi.fn().mockResolvedValue({
-    action: "idle",
-    providerRequests: 0,
-  }),
+  runConfiguredLifecycle: mocks.run,
 }));
 vi.mock("@/lib/firebase/server", () => ({
   AdminFootballSyncStore: class {},
 }));
 
 import { POST } from "./route";
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  vi.stubEnv("NEXT_PUBLIC_FIREBASE_ENVIRONMENT", "local");
+  mocks.run.mockResolvedValue({ action: "idle", providerRequests: 0 });
+});
 
 describe("POST /api/internal/match-lifecycle", () => {
   it("rejects missing and incorrect secrets", async () => {
@@ -44,5 +49,43 @@ describe("POST /api/internal/match-lifecycle", () => {
     expect(response.status).toBe(200);
     expect(body).not.toContain("correct-secret");
     expect(body).not.toContain("provider-secret");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("fails safely when the API key is missing", async () => {
+    vi.stubEnv("CRON_SECRET", "correct-secret");
+    const response = await POST(
+      new Request("http://local.test", {
+        method: "POST",
+        headers: { authorization: "Bearer correct-secret" },
+      }),
+    );
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Lifecycle synchronization is not configured.",
+    });
+    expect(mocks.run).not.toHaveBeenCalled();
+  });
+
+  it("does not return provider failure details or secrets", async () => {
+    vi.stubEnv("CRON_SECRET", "correct-secret");
+    vi.stubEnv("API_FOOTBALL_KEY", "provider-secret");
+    mocks.run.mockResolvedValue({
+      action: "retryable_error",
+      matchId: "match-1",
+      providerRequests: 1,
+      reason: "provider-secret remote response body",
+    });
+    const response = await POST(
+      new Request("http://local.test", {
+        method: "POST",
+        headers: { authorization: "Bearer correct-secret" },
+      }),
+    );
+    const body = JSON.stringify(await response.json());
+    expect(response.status).toBe(503);
+    expect(body).toContain("match-1");
+    expect(body).not.toContain("provider-secret");
+    expect(body).not.toContain("response body");
   });
 });

--- a/src/app/api/internal/match-lifecycle/route.ts
+++ b/src/app/api/internal/match-lifecycle/route.ts
@@ -2,20 +2,21 @@ import { initialClub } from "@/config/club";
 import { runConfiguredLifecycle } from "@/application/run-lifecycle";
 import { AdminFootballSyncStore } from "@/lib/firebase/server";
 import { isAuthorizedCronRequest } from "@/lib/server/cron-auth";
+import { requireLifecycleRuntimeConfig } from "@/lib/server/environment";
 
 export const runtime = "nodejs";
 
 export async function POST(request: Request) {
   const secret = process.env.CRON_SECRET ?? "";
   if (!isAuthorizedCronRequest(request.headers.get("authorization"), secret)) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    return json({ error: "Unauthorized" }, 401);
   }
-  const apiKey = process.env.API_FOOTBALL_KEY;
-  if (apiKey === undefined || apiKey.trim() === "") {
-    return Response.json(
-      { error: "Lifecycle synchronization is not configured." },
-      { status: 503 },
-    );
+  let apiKey: string;
+  try {
+    apiKey = requireLifecycleRuntimeConfig().apiFootballKey;
+  } catch {
+    console.error("Lifecycle configuration validation failed.");
+    return json({ error: "Lifecycle synchronization is not configured." }, 503);
   }
 
   try {
@@ -24,17 +25,31 @@ export async function POST(request: Request) {
       new AdminFootballSyncStore(),
       apiKey,
     );
-    return Response.json(result);
-  } catch (error) {
-    return Response.json(
-      {
-        action: "retryable_error",
-        reason:
-          error instanceof Error
-            ? error.message
-            : "Lifecycle synchronization failed.",
-      },
-      { status: 500 },
-    );
+    if (
+      result.action === "retryable_error" ||
+      result.action === "preparing_rating"
+    ) {
+      console.error("Lifecycle run requires retry.", {
+        action: result.action,
+        matchId: result.matchId,
+        providerRequests: result.providerRequests,
+      });
+    }
+    const safeResult = {
+      action: result.action,
+      ...(result.matchId ? { matchId: result.matchId } : {}),
+      providerRequests: result.providerRequests,
+    };
+    return json(safeResult, result.action === "retryable_error" ? 503 : 200);
+  } catch {
+    console.error("Lifecycle synchronization failed before completion.");
+    return json({ action: "retryable_error" }, 500);
   }
+}
+
+function json(body: object, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
 }

--- a/src/app/api/matches/[matchId]/ballot/route.test.ts
+++ b/src/app/api/matches/[matchId]/ballot/route.test.ts
@@ -100,7 +100,11 @@ describe("ballot API", () => {
 
   it("fails closed for malformed JSON and persistence failures", async () => {
     const malformed = await POST(
-      new Request("http://local/api", { method: "POST", body: "{" }),
+      new Request("http://local/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{",
+      }),
       context,
     );
     expect(malformed.status).toBe(400);
@@ -111,5 +115,33 @@ describe("ballot API", () => {
     await expect(unavailable.json()).resolves.toEqual({
       status: "data_unavailable",
     });
+  });
+
+  it("rejects unsupported media, oversized payloads, and invalid match IDs", async () => {
+    const unsupported = await POST(
+      new Request("http://local/api", { method: "POST", body: "{}" }),
+      context,
+    );
+    expect(unsupported.status).toBe(415);
+
+    const oversized = await POST(
+      new Request("http://local/api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: "x".repeat(17 * 1024) }),
+      }),
+      context,
+    );
+    expect(oversized.status).toBe(413);
+
+    const invalidContext = { params: Promise.resolve({ matchId: "../bad" }) };
+    const invalid = await GET(new Request("http://local/api"), invalidContext);
+    expect(invalid.status).toBe(400);
+    expect(mocks.hasSubmitted).not.toHaveBeenCalled();
+  });
+
+  it("marks every API response as non-cacheable", async () => {
+    const response = await GET(new Request("http://local/api"), context);
+    expect(response.headers.get("cache-control")).toBe("no-store");
   });
 });

--- a/src/app/api/matches/[matchId]/ballot/route.ts
+++ b/src/app/api/matches/[matchId]/ballot/route.ts
@@ -2,6 +2,10 @@ import { AdminBallotService } from "@/lib/firebase/server";
 import { verifyVoterRequest } from "@/lib/server/voter-token";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BALLOT_BYTES = 16 * 1024;
+const MATCH_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
 export async function GET(
   request: Request,
@@ -11,17 +15,20 @@ export async function GET(
     request.headers.get("authorization"),
   );
   if (voterId === null) {
-    return Response.json({ status: "unauthorized" }, { status: 401 });
+    return json({ status: "unauthorized" }, 401);
   }
   const { matchId } = await params;
+  if (!MATCH_ID_PATTERN.test(matchId))
+    return json({ status: "invalid_match" }, 400);
   try {
     const submitted = await new AdminBallotService().hasSubmitted(
       matchId,
       voterId,
     );
-    return Response.json({ status: submitted ? "submitted" : "available" });
+    return json({ status: submitted ? "submitted" : "available" });
   } catch {
-    return Response.json({ status: "data_unavailable" }, { status: 503 });
+    console.error("Ballot status read failed.", { matchId });
+    return json({ status: "data_unavailable" }, 503);
   }
 }
 
@@ -33,20 +40,39 @@ export async function POST(
     request.headers.get("authorization"),
   );
   if (voterId === null) {
-    return Response.json({ status: "unauthorized" }, { status: 401 });
+    return json({ status: "unauthorized" }, 401);
+  }
+  if (
+    !request.headers
+      .get("content-type")
+      ?.toLowerCase()
+      .startsWith("application/json")
+  ) {
+    return json({ status: "invalid_ballot" }, 415);
+  }
+  const contentLength = Number(request.headers.get("content-length") ?? "0");
+  if (!Number.isFinite(contentLength) || contentLength > MAX_BALLOT_BYTES) {
+    return json({ status: "invalid_ballot" }, 413);
   }
   let input: unknown;
   try {
-    input = await request.json();
+    const body = await request.text();
+    if (new TextEncoder().encode(body).byteLength > MAX_BALLOT_BYTES) {
+      return json({ status: "invalid_ballot" }, 413);
+    }
+    input = JSON.parse(body);
   } catch {
-    return Response.json({ status: "invalid_ballot" }, { status: 400 });
+    return json({ status: "invalid_ballot" }, 400);
   }
   const { matchId } = await params;
+  if (!MATCH_ID_PATTERN.test(matchId))
+    return json({ status: "invalid_match" }, 400);
   let result;
   try {
     result = await new AdminBallotService().submit(matchId, voterId, input);
   } catch {
-    return Response.json({ status: "data_unavailable" }, { status: 503 });
+    console.error("Ballot submission failed.", { matchId });
+    return json({ status: "data_unavailable" }, 503);
   }
   const statusCode =
     result.status === "created"
@@ -58,5 +84,12 @@ export async function POST(
           : result.status === "data_unavailable"
             ? 503
             : 403;
-  return Response.json(result, { status: statusCode });
+  return json(result, statusCode);
+}
+
+function json(body: object, status = 200) {
+  return Response.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
 }

--- a/src/app/matches/[matchId]/rate/page.tsx
+++ b/src/app/matches/[matchId]/rate/page.tsx
@@ -6,6 +6,9 @@ import { getMessages } from "@/i18n/messages";
 import { getLocale } from "@/i18n/server";
 import { AdminBallotService } from "@/lib/firebase/server";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export default async function RateMatchPage({
   params,
 }: {
@@ -20,7 +23,7 @@ export default async function RateMatchPage({
   try {
     pageState = await new AdminBallotService().getPageState(matchId);
   } catch {
-    // The route renders a safe unavailable state when trusted data cannot load.
+    console.error("Ballot page data is temporarily unavailable.", { matchId });
   }
   return (
     <AppShell

--- a/src/app/matches/[matchId]/results/page.tsx
+++ b/src/app/matches/[matchId]/results/page.tsx
@@ -5,6 +5,9 @@ import { getMessages } from "@/i18n/messages";
 import { getLocale } from "@/i18n/server";
 import { AdminResultService } from "@/lib/firebase/server";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export default async function MatchResultsPage({
   params,
 }: {
@@ -19,7 +22,7 @@ export default async function MatchResultsPage({
   try {
     pageState = await new AdminResultService().getPageState(matchId);
   } catch {
-    // Keep the public route fail-closed when trusted data cannot load.
+    console.error("Result page data is temporarily unavailable.", { matchId });
   }
   return (
     <AppShell

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -50,6 +50,14 @@ describe("Home", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders a localized safe persistence failure instead of an empty state", () => {
+    render(<HomeContent locale="en" unavailable />);
+    expect(
+      screen.getByRole("heading", { name: "We couldn't load the match" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No active rating")).not.toBeInTheDocument();
+  });
+
   it("renders real upcoming match context without assuming the tracked Team is home", () => {
     render(
       <HomeContent

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,23 +8,32 @@ import { getMessages } from "@/i18n/messages";
 import { getLocale } from "@/i18n/server";
 import { getLifecycleHomeMatch } from "@/lib/firebase/lifecycle-read";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export default async function Home() {
   const locale = await getLocale();
   let match: Match | null = null;
+  let unavailable = false;
   try {
     match = await getLifecycleHomeMatch(initialClub.teamId);
   } catch {
-    // The honest empty state remains available when server persistence is not configured.
+    unavailable = true;
+    console.error("Home lifecycle data is temporarily unavailable.");
   }
-  return <HomeContent locale={locale} match={match} />;
+  return (
+    <HomeContent locale={locale} match={match} unavailable={unavailable} />
+  );
 }
 
 export function HomeContent({
   locale,
   match = null,
+  unavailable = false,
 }: {
   locale: Locale;
   match?: Match | null;
+  unavailable?: boolean;
 }) {
   const messages = getMessages(locale);
   return (
@@ -43,7 +52,13 @@ export function HomeContent({
           </p>
         </section>
         {match === null ? (
-          <EmptyRatingState messages={messages.home.noActiveRating} />
+          <EmptyRatingState
+            messages={
+              unavailable
+                ? messages.home.lifecycleUnavailable
+                : messages.home.noActiveRating
+            }
+          />
         ) : (
           <MatchLifecyclePanel
             match={match}

--- a/src/application/match-lifecycle.test.ts
+++ b/src/application/match-lifecycle.test.ts
@@ -342,6 +342,60 @@ describe("match lifecycle synchronization", () => {
     );
   });
 
+  it("does not let a finalized result block preparing or the next fixture", () => {
+    const closed = match({
+      id: "closed",
+      status: "finished",
+      ratingState: "rating_closed",
+      kickoffAt: "2026-08-28T20:00:00.000Z",
+    });
+    const preparing = match({
+      id: "preparing",
+      status: "finished",
+      ratingState: "preparing_rating",
+      kickoffAt: "2026-08-29T17:00:00.000Z",
+    });
+    const upcoming = match({
+      id: "upcoming",
+      kickoffAt: "2026-08-30T20:00:00.000Z",
+    });
+    expect(selectRelevantMatch([closed, preparing, upcoming], NOW)?.id).toBe(
+      "preparing",
+    );
+    expect(selectRelevantMatch([closed, upcoming], NOW)?.id).toBe("upcoming");
+  });
+
+  it("discovers and selects a next fixture after finalization", async () => {
+    const store = new MemoryStore([
+      match({
+        id: "closed",
+        status: "finished",
+        ratingState: "rating_closed",
+        kickoffAt: "2026-08-28T20:00:00.000Z",
+      }),
+    ]);
+    store.metadata = null;
+    const result = await runMatchLifecycle({
+      teamId: "tracked-team",
+      store,
+      provider: new FixtureProvider(fixture("scheduled")),
+      now: () => NOW,
+      discoverFixtures: async () => {
+        store.matches.push(
+          match({
+            id: "next-match",
+            kickoffAt: "2026-08-30T20:00:00.000Z",
+          }),
+        );
+      },
+      syncParticipants: async () => undefined,
+    });
+    expect(result).toMatchObject({
+      action: "discovered",
+      matchId: "next-match",
+    });
+  });
+
   it("does not open rating windows for stale historical finished fixtures", () => {
     const historical = match({
       id: "historical",

--- a/src/application/match-lifecycle.ts
+++ b/src/application/match-lifecycle.ts
@@ -212,10 +212,6 @@ export function selectRelevantMatch(
         now < new Date(match.votingClosesAt),
     ) ??
     byKickoff.find((match) => match.status === "live") ??
-    [...byKickoff]
-      .reverse()
-      .find((match) => match.ratingState === "rating_closed") ??
-    byKickoff.find((match) => match.ratingState === "rating_ready") ??
     byKickoff.find(
       (match) =>
         match.status === "finished" &&
@@ -227,7 +223,11 @@ export function selectRelevantMatch(
     byKickoff.find(
       (match) =>
         match.status === "scheduled" && new Date(match.kickoffAt) >= now,
-    )
+    ) ??
+    [...byKickoff]
+      .reverse()
+      .find((match) => match.ratingState === "rating_closed") ??
+    byKickoff.find((match) => match.ratingState === "rating_ready")
   );
 }
 

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -33,6 +33,13 @@ export const enMessages = {
       privacy:
         "Results stay hidden while voting is open to keep every rating independent.",
     },
+    lifecycleUnavailable: {
+      status: "Service unavailable",
+      title: "We couldn't load the match",
+      description:
+        "Match information is temporarily unavailable. Try again in a few minutes.",
+      privacy: "Your ratings and private results remain protected.",
+    },
     matchLifecycle: {
       versus: "VS",
       upcoming: {

--- a/src/i18n/messages/es.ts
+++ b/src/i18n/messages/es.ts
@@ -31,6 +31,14 @@ export const esMessages = {
       privacy:
         "Los resultados permanecen ocultos mientras la votación está abierta para mantener cada calificación independiente.",
     },
+    lifecycleUnavailable: {
+      status: "Servicio no disponible",
+      title: "No pudimos cargar el partido",
+      description:
+        "La información del partido no está disponible temporalmente. Intenta de nuevo en unos minutos.",
+      privacy:
+        "Tus calificaciones y los resultados privados permanecen protegidos.",
+    },
     matchLifecycle: {
       versus: "VS",
       upcoming: {

--- a/src/lib/firebase/browser.test.ts
+++ b/src/lib/firebase/browser.test.ts
@@ -69,6 +69,19 @@ describe("browser Firebase Auth", () => {
     );
     expect(getAuth).not.toHaveBeenCalled();
   });
+
+  it("rejects a demo project in production without connecting an emulator", async () => {
+    stubCompleteDevelopmentConfig();
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_ENVIRONMENT", "production");
+    vi.stubEnv("NEXT_PUBLIC_FIREBASE_PROJECT_ID", "demo-production");
+    const { getBrowserAuth } = await import("./browser");
+
+    expect(() => getBrowserAuth()).toThrow(
+      "Firebase environment configuration is missing or invalid",
+    );
+    expect(connectAuthEmulator).not.toHaveBeenCalled();
+    expect(getAuth).not.toHaveBeenCalled();
+  });
 });
 
 function stubCompleteDevelopmentConfig() {

--- a/src/lib/firebase/browser.ts
+++ b/src/lib/firebase/browser.ts
@@ -12,6 +12,7 @@ import {
   firebaseEnvironmentName,
   firestoreEmulator,
   isFirebaseConfigured,
+  isFirebaseEnvironmentSafe,
 } from "./config";
 
 const LOCAL_PROJECT_ID = "demo-rating-app-local";
@@ -21,7 +22,7 @@ const emulatorConnections = globalThis as typeof globalThis & {
 };
 
 export function getBrowserFirebaseApp(): FirebaseApp {
-  if (!isFirebaseConfigured) {
+  if (!isFirebaseConfigured || !isFirebaseEnvironmentSafe) {
     throw new Error(
       "Firebase environment configuration is missing or invalid. See .env.example.",
     );

--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -32,3 +32,10 @@ export const isFirebaseConfigured =
   firebaseEnvironmentName === "local" ||
   (firebaseEnvironmentName !== null &&
     Object.values(firebaseEnvironment).every(Boolean));
+
+export const isFirebaseEnvironmentSafe =
+  isFirebaseConfigured &&
+  (firebaseEnvironmentName === "local"
+    ? !firebaseEnvironment.projectId ||
+      firebaseEnvironment.projectId.startsWith("demo-")
+    : !firebaseEnvironment.projectId?.startsWith("demo-"));

--- a/src/lib/firebase/lifecycle-read.ts
+++ b/src/lib/firebase/lifecycle-read.ts
@@ -7,7 +7,6 @@ export async function getLifecycleHomeMatch(
   teamId: string,
   now = new Date(),
 ): Promise<Match | null> {
-  if (!process.env.FIREBASE_ADMIN_PROJECT_ID) return null;
   const matches = await new AdminFootballSyncStore().listMatches(teamId);
   return selectRelevantMatch(matches, now) ?? null;
 }

--- a/src/lib/firebase/server.ts
+++ b/src/lib/firebase/server.ts
@@ -34,6 +34,7 @@ import type {
   MatchLifecycleStore,
   SyncWriteCounts,
 } from "@/domain/ports";
+import { readFirebaseAdminRuntimeConfig } from "@/lib/server/environment";
 
 const TIMESTAMP_FIELDS = new Set([
   "createdAt",
@@ -48,20 +49,20 @@ const TIMESTAMP_FIELDS = new Set([
 ]);
 
 export function getServerFirestore(): Firestore {
-  if (getApps().length === 0) {
-    const projectId = required("FIREBASE_ADMIN_PROJECT_ID");
-    const emulator = process.env.FIRESTORE_EMULATOR_HOST !== undefined;
+  const config = readFirebaseAdminRuntimeConfig();
+  if (config.emulator) {
+    process.env.FIRESTORE_EMULATOR_HOST = config.firestoreEmulatorHost;
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = config.authEmulatorHost;
+  }
+  if (!getApps().some((app) => app.name === "[DEFAULT]")) {
     initializeApp({
-      projectId,
-      credential: emulator
+      projectId: config.projectId,
+      credential: config.emulator
         ? applicationDefault()
         : cert({
-            projectId,
-            clientEmail: required("FIREBASE_ADMIN_CLIENT_EMAIL"),
-            privateKey: required("FIREBASE_ADMIN_PRIVATE_KEY").replace(
-              /\\n/g,
-              "\n",
-            ),
+            projectId: config.projectId,
+            clientEmail: config.clientEmail!,
+            privateKey: config.privateKey!,
           }),
     });
   }
@@ -501,12 +502,6 @@ function compareParticipants(
   );
 }
 
-function required(name: string): string {
-  const value = process.env[name];
-  if (value === undefined || value.trim() === "")
-    throw new Error(`${name} is required for trusted server persistence.`);
-  return value;
-}
 function toDocument(value: object): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(value)

--- a/src/lib/server/environment.test.ts
+++ b/src/lib/server/environment.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { readFirebaseAdminRuntimeConfig } from "./environment";
+
+const hosted = {
+  NEXT_PUBLIC_FIREBASE_ENVIRONMENT: "production",
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: "rating-app-production",
+  FIREBASE_ADMIN_PROJECT_ID: "rating-app-production",
+  FIREBASE_ADMIN_CLIENT_EMAIL: "admin@example.test",
+  FIREBASE_ADMIN_PRIVATE_KEY:
+    "-----BEGIN PRIVATE KEY-----\\nplaceholder\\n-----END PRIVATE KEY-----\\n",
+};
+
+describe("server Firebase environment validation", () => {
+  it("derives safe local Admin emulator configuration", () => {
+    expect(
+      readFirebaseAdminRuntimeConfig({
+        NEXT_PUBLIC_FIREBASE_ENVIRONMENT: "local",
+      }),
+    ).toEqual({
+      environment: "local",
+      projectId: "demo-rating-app-local",
+      emulator: true,
+      firestoreEmulatorHost: "127.0.0.1:8080",
+      authEmulatorHost: "127.0.0.1:9099",
+    });
+  });
+
+  it("rejects non-demo local projects", () => {
+    expect(() =>
+      readFirebaseAdminRuntimeConfig({
+        NEXT_PUBLIC_FIREBASE_ENVIRONMENT: "local",
+        FIREBASE_ADMIN_PROJECT_ID: "rating-app-production",
+      }),
+    ).toThrow("demo-*");
+    expect(() =>
+      readFirebaseAdminRuntimeConfig({
+        NEXT_PUBLIC_FIREBASE_ENVIRONMENT: "local",
+        NEXT_PUBLIC_FIREBASE_PROJECT_ID: "rating-app-development",
+      }),
+    ).toThrow("demo-*");
+  });
+
+  it("rejects demo projects and emulator hosts in production", () => {
+    expect(() =>
+      readFirebaseAdminRuntimeConfig({
+        ...hosted,
+        FIREBASE_ADMIN_PROJECT_ID: "demo-production",
+        NEXT_PUBLIC_FIREBASE_PROJECT_ID: "demo-production",
+      }),
+    ).toThrow("demo-*");
+    expect(() =>
+      readFirebaseAdminRuntimeConfig({
+        ...hosted,
+        FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080",
+      }),
+    ).toThrow("must not use emulator");
+  });
+
+  it("requires matching Web/Admin projects and well-formed credentials", () => {
+    expect(() =>
+      readFirebaseAdminRuntimeConfig({
+        NEXT_PUBLIC_FIREBASE_ENVIRONMENT: "production",
+      }),
+    ).toThrow("FIREBASE_ADMIN_PROJECT_ID is required");
+    expect(() =>
+      readFirebaseAdminRuntimeConfig({
+        ...hosted,
+        FIREBASE_ADMIN_PROJECT_ID: "another-project",
+      }),
+    ).toThrow("must match");
+    expect(() =>
+      readFirebaseAdminRuntimeConfig({
+        ...hosted,
+        FIREBASE_ADMIN_PRIVATE_KEY: "not-a-key",
+      }),
+    ).toThrow("malformed");
+  });
+
+  it("accepts complete hosted configuration and expands key newlines", () => {
+    const result = readFirebaseAdminRuntimeConfig(hosted);
+    expect(result).toMatchObject({
+      environment: "production",
+      projectId: "rating-app-production",
+      emulator: false,
+      clientEmail: "admin@example.test",
+    });
+    expect(result.privateKey).toContain("\nplaceholder\n");
+  });
+});

--- a/src/lib/server/environment.ts
+++ b/src/lib/server/environment.ts
@@ -1,0 +1,111 @@
+export type RuntimeEnvironment = "local" | "development" | "production";
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+export interface FirebaseAdminRuntimeConfig {
+  environment: RuntimeEnvironment;
+  projectId: string;
+  emulator: boolean;
+  firestoreEmulatorHost?: string;
+  authEmulatorHost?: string;
+  clientEmail?: string;
+  privateKey?: string;
+}
+
+const LOCAL_PROJECT_ID = "demo-rating-app-local";
+
+export function readFirebaseAdminRuntimeConfig(
+  environment: Environment = process.env,
+): FirebaseAdminRuntimeConfig {
+  const mode = runtimeEnvironment(environment);
+  if (mode === "local") {
+    const projectId = environment.FIREBASE_ADMIN_PROJECT_ID || LOCAL_PROJECT_ID;
+    const webProjectId = environment.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+    if (
+      !projectId.startsWith("demo-") ||
+      (webProjectId !== undefined &&
+        webProjectId !== "" &&
+        (webProjectId !== projectId || !webProjectId.startsWith("demo-")))
+    ) {
+      throw new Error("Local Firebase Admin requires a demo-* project ID.");
+    }
+    return {
+      environment: mode,
+      projectId,
+      emulator: true,
+      firestoreEmulatorHost:
+        environment.FIRESTORE_EMULATOR_HOST ||
+        `${environment.NEXT_PUBLIC_FIRESTORE_EMULATOR_HOST || "127.0.0.1"}:${validPort(environment.NEXT_PUBLIC_FIRESTORE_EMULATOR_PORT, "8080")}`,
+      authEmulatorHost:
+        environment.FIREBASE_AUTH_EMULATOR_HOST ||
+        `${environment.NEXT_PUBLIC_AUTH_EMULATOR_HOST || "127.0.0.1"}:${validPort(environment.NEXT_PUBLIC_AUTH_EMULATOR_PORT, "9099")}`,
+    };
+  }
+
+  if (
+    environment.FIRESTORE_EMULATOR_HOST ||
+    environment.FIREBASE_AUTH_EMULATOR_HOST
+  ) {
+    throw new Error("Hosted Firebase Admin must not use emulator hosts.");
+  }
+  const projectId = required(environment, "FIREBASE_ADMIN_PROJECT_ID");
+  if (projectId.startsWith("demo-")) {
+    throw new Error("Hosted Firebase Admin must not use a demo-* project ID.");
+  }
+  const webProjectId = required(environment, "NEXT_PUBLIC_FIREBASE_PROJECT_ID");
+  if (webProjectId !== projectId) {
+    throw new Error("Firebase Web and Admin project IDs must match.");
+  }
+  const clientEmail = required(environment, "FIREBASE_ADMIN_CLIENT_EMAIL");
+  const privateKey = required(
+    environment,
+    "FIREBASE_ADMIN_PRIVATE_KEY",
+  ).replace(/\\n/g, "\n");
+  if (
+    !privateKey.includes("-----BEGIN PRIVATE KEY-----") ||
+    !privateKey.includes("-----END PRIVATE KEY-----")
+  ) {
+    throw new Error("FIREBASE_ADMIN_PRIVATE_KEY is malformed.");
+  }
+  return {
+    environment: mode,
+    projectId,
+    emulator: false,
+    clientEmail,
+    privateKey,
+  };
+}
+
+export function requireLifecycleRuntimeConfig(
+  environment: Environment = process.env,
+) {
+  const cronSecret = required(environment, "CRON_SECRET");
+  const apiFootballKey = required(environment, "API_FOOTBALL_KEY");
+  return {
+    cronSecret,
+    apiFootballKey,
+    firebaseAdmin: readFirebaseAdminRuntimeConfig(environment),
+  };
+}
+
+function runtimeEnvironment(environment: Environment): RuntimeEnvironment {
+  const value = environment.NEXT_PUBLIC_FIREBASE_ENVIRONMENT;
+  if (value === "local" || value === "development" || value === "production") {
+    return value;
+  }
+  throw new Error("NEXT_PUBLIC_FIREBASE_ENVIRONMENT is missing or invalid.");
+}
+
+function required(environment: Environment, name: string) {
+  const value = environment[name];
+  if (!value?.trim()) throw new Error(`${name} is required.`);
+  return value;
+}
+
+function validPort(value: string | undefined, fallback: string) {
+  const port = value || fallback;
+  if (!/^\d+$/.test(port) || Number(port) < 1 || Number(port) > 65535) {
+    throw new Error("Firebase emulator port is invalid.");
+  }
+  return port;
+}

--- a/tests/firebase/teams.rules.test.ts
+++ b/tests/firebase/teams.rules.test.ts
@@ -129,6 +129,7 @@ describe("Team persistence and rules", () => {
     "matches",
     "players",
     "coaches",
+    "footballSyncMetadata",
     "matches/example/participants",
     "matches/example/coachAssignments",
   ])(


### PR DESCRIPTION
## Summary

- validate local, development, and production Firebase runtime boundaries before trusted server access
- add a protected, sanitized readiness endpoint and harden lifecycle/ballot API responses
- keep lifecycle-driven fixture discovery moving after finalized matches
- add an explicit, guarded, idempotent production Team bootstrap command
- document environment inventory, deployment order, smoke checks, rollback, rotation, and pilot limitations
- bound the scheduled lifecycle request beneath the GitHub Actions job interval

## Production readiness checklist

- [x] Firebase Admin and browser project IDs are validated and must agree in hosted environments
- [x] Demo projects and emulator hosts are rejected in hosted environments
- [x] Local trusted services default to the explicit demo project and emulator endpoints
- [x] Dynamic match pages and internal/API responses cannot be served from stale caches
- [x] Internal endpoints use timing-safe authorization and sanitized failures
- [x] Ballot input has content-type, size, and match-ID boundaries
- [x] Firestore rules retain default deny; no composite indexes are currently required
- [x] Production Team bootstrap requires an exact project, provider ID, and confirmation phrase
- [x] Production operations, recovery, rollback, secret rotation, and cost monitoring are documented
- [x] No secret, service-account file, deployment, or production data mutation is included

## Verification

- `npm ci`
- `npm run verify`
  - formatting passed
  - lint passed
  - typecheck passed
  - 25 test files / 138 tests passed
  - production build passed; all data-sensitive routes are dynamic
- Firebase emulator suite: 5 files / 40 tests passed
- `git diff --check`
- tracked-file secret scan found no credential or private-key material

## Manual smoke coverage

Using only the Firebase Auth and Firestore emulators with the demo project:

- scheduled, live, preparing, voting-open, finalized-result, and next-fixture states
- Spanish and English Home, ballot, and results flows
- two anonymous voters, deterministic duplicate rejection, hidden pre-close results, and finalized aggregation
- finalized result yielding to the next scheduled fixture
- protected health and lifecycle endpoint rejection
- responsive checks at 320px, 390px, and 430px with no horizontal overflow

## Dependency audit disposition

`npm audit --audit-level=moderate` reports eight transitive moderate findings through Firebase Admin's Google client stack. The app does not call the affected UUID APIs, and the offered force fix would downgrade Firebase Admin across a breaking major boundary. This is documented as a controlled-pilot limitation to monitor upstream rather than applying an unsafe downgrade.

## Deployment note

This PR prepares the repository and runbook only. It does **not** deploy the application, change GitHub/Firebase/Vercel settings, write production data, or enable the scheduler. Follow `PRODUCTION_RUNBOOK.md` after review and approval.

## Rollback

Revert commit `3672417` for the code changes. If rollout has begun, disable the scheduler first, roll back the hosting release, and follow the runbook's Firebase/config rollback steps.
