### PR TITLE
fix: make production bootstrap Windows compatible

### DIFF
--- a/scripts/bootstrap-production-team.ts
+++ b/scripts/bootstrap-production-team.ts
@@ -40,7 +40,7 @@ export function parseProductionBootstrapArguments(
   return { projectId, providerTeamId };
 }
 
-async function main() {
+export async function main() {
   const arguments_ = parseProductionBootstrapArguments(process.argv.slice(2));
   const config = readFirebaseAdminRuntimeConfig();
   if (config.environment !== "production" || config.emulator) {
@@ -113,5 +113,8 @@ function usageError() {
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  await main();
+  void main().catch(() => {
+    console.error("Production Team bootstrap failed.");
+    process.exitCode = 1;
+  });
 }


### PR DESCRIPTION
## Summary

- replace the production bootstrap CLI's top-level `await` with a Windows/CommonJS-compatible promise handler
- export `main()` so importing the module remains side-effect-free and the async entrypoint stays testable
- return a non-zero process exit code with a generic, secret-safe failure message

## Root cause

The existing `tsx` execution path on Windows transforms this script as CommonJS, where top-level `await` is unsupported. The process therefore failed before any bootstrap validation or Firebase operation could run.

## Safety

All production bootstrap parsing, confirmation, environment, emulator, project-match, credential, canonical-Team, idempotency, and conflict guards are unchanged. The documented command and operational behavior are unchanged, so `PRODUCTION_RUNBOOK.md` remains unchanged.

No production bootstrap command was run. No deployment or production data mutation was performed.

## Verification

- `git diff --check` passed
- manual inspection confirmed the diff is limited to the CLI entrypoint and `main()` export

Automated tests were not run per user instruction.
