### PR TITLE
fix: add actionable production health diagnostics

### DIFF
--- a/PRODUCTION_RUNBOOK.md
+++ b/PRODUCTION_RUNBOOK.md
@@ -59,7 +59,7 @@ Current server queries need only automatic single-field indexes; `firestore.inde
 2. Configure all Vercel public and server-only variables for Production only.
 3. Confirm Vercel uses Node.js 22, then deploy the reviewed commit.
 4. Confirm the public shell loads and Anonymous Auth succeeds; do not submit a ballot.
-5. Call `GET /api/internal/health` with `Authorization: Bearer <CRON_SECRET>`. Before Team bootstrap, `not_ready` is expected; unauthorized calls must return 401.
+5. Call `GET /api/internal/health` with `Authorization: Bearer <CRON_SECRET>`. Before Team bootstrap, `not_ready` with reason `team_missing` is expected; `configuration` identifies invalid deployment configuration, and `firebase_admin` identifies Admin initialization or Firestore connectivity failure. Unauthorized calls must return 401 without a reason.
 6. From a controlled operator environment with the production variables loaded, confirm the API-Football provider Team ID independently, then run:
 
    `npm run bootstrap:production-team -- --project-id <exact-production-project-id> --provider-team-id <confirmed-id> --confirm bootstrap-production-team`

--- a/src/app/api/internal/health/route.test.ts
+++ b/src/app/api/internal/health/route.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ getTeam: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  doc: vi.fn(),
+  get: vi.fn(),
+  getServerFirestore: vi.fn(),
+}));
 vi.mock("@/lib/firebase/server", () => ({
-  AdminFootballSyncStore: class {
-    getTeam = mocks.getTeam;
-  },
+  getServerFirestore: mocks.getServerFirestore,
 }));
 
 import { GET } from "./route";
@@ -15,14 +17,27 @@ beforeEach(() => {
   vi.stubEnv("NEXT_PUBLIC_FIREBASE_ENVIRONMENT", "local");
   vi.stubEnv("CRON_SECRET", "cron-secret");
   vi.stubEnv("API_FOOTBALL_KEY", "provider-key");
-  mocks.getTeam.mockResolvedValue({ id: "club-sport-herediano" });
+  mocks.get.mockResolvedValue({ exists: true });
+  mocks.doc.mockReturnValue({ get: mocks.get });
+  mocks.getServerFirestore.mockReturnValue({ doc: mocks.doc });
 });
 
 describe("GET /api/internal/health", () => {
   it("fails closed without the scheduler credential", async () => {
     const response = await GET(new Request("http://local/health"));
     expect(response.status).toBe(401);
-    expect(mocks.getTeam).not.toHaveBeenCalled();
+    expect(mocks.getServerFirestore).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with the wrong scheduler credential", async () => {
+    const response = await GET(
+      new Request("http://local/health", {
+        headers: { Authorization: "Bearer wrong-secret" },
+      }),
+    );
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ status: "unauthorized" });
+    expect(mocks.getServerFirestore).not.toHaveBeenCalled();
   });
 
   it("reports only a safe ready state", async () => {
@@ -36,16 +51,46 @@ describe("GET /api/internal/health", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
-  it("returns a sanitized not-ready response for configuration or Firestore failures", async () => {
-    mocks.getTeam.mockRejectedValue(new Error("secret credential content"));
+  it("reports a safe configuration failure", async () => {
+    vi.stubEnv("API_FOOTBALL_KEY", "");
     const response = await GET(
       new Request("http://local/health", {
         headers: { Authorization: "Bearer cron-secret" },
       }),
     );
     expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: "not_ready",
+      reason: "configuration",
+    });
+    expect(mocks.getServerFirestore).not.toHaveBeenCalled();
+  });
+
+  it("reports a safe Firebase Admin failure without leaking the error", async () => {
+    mocks.get.mockRejectedValue(new Error("secret credential content"));
+    const response = await authorizedRequest();
+    expect(response.status).toBe(503);
     const body = JSON.stringify(await response.json());
-    expect(body).toBe('{"status":"not_ready"}');
+    expect(body).toBe('{"status":"not_ready","reason":"firebase_admin"}');
     expect(body).not.toContain("credential");
+    expect(body).not.toContain("secret");
+  });
+
+  it("reports when the canonical Team is missing", async () => {
+    mocks.get.mockResolvedValue({ exists: false });
+    const response = await authorizedRequest();
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: "not_ready",
+      reason: "team_missing",
+    });
   });
 });
+
+function authorizedRequest() {
+  return GET(
+    new Request("http://local/health", {
+      headers: { Authorization: "Bearer cron-secret" },
+    }),
+  );
+}

--- a/src/app/api/internal/health/route.ts
+++ b/src/app/api/internal/health/route.ts
@@ -1,5 +1,5 @@
 import { initialClub } from "@/config/club";
-import { AdminFootballSyncStore } from "@/lib/firebase/server";
+import { getServerFirestore } from "@/lib/firebase/server";
 import { isAuthorizedCronRequest } from "@/lib/server/cron-auth";
 import { requireLifecycleRuntimeConfig } from "@/lib/server/environment";
 
@@ -13,12 +13,32 @@ export async function GET(request: Request) {
   }
   try {
     requireLifecycleRuntimeConfig();
-    await new AdminFootballSyncStore().getTeam(initialClub.teamId);
-    return json({ status: "ready" });
   } catch {
-    console.error("Internal readiness check failed.");
-    return json({ status: "not_ready" }, 503);
+    console.error("Production health configuration check failed.");
+    return notReady("configuration");
   }
+
+  let teamExists: boolean;
+  try {
+    const snapshot = await getServerFirestore()
+      .doc(`teams/${initialClub.teamId}`)
+      .get();
+    teamExists = snapshot.exists;
+  } catch {
+    console.error("Production health Firebase Admin check failed.");
+    return notReady("firebase_admin");
+  }
+
+  if (!teamExists) {
+    console.error("Production health canonical Team is missing.");
+    return notReady("team_missing");
+  }
+
+  return json({ status: "ready" });
+}
+
+function notReady(reason: "configuration" | "firebase_admin" | "team_missing") {
+  return json({ status: "not_ready", reason }, 503);
 }
 
 function json(body: object, status = 200) {


### PR DESCRIPTION
## Summary

- preserve authorization-first health checks while splitting authenticated readiness failures into safe stages
- return `configuration`, `firebase_admin`, or `team_missing` without raw exception details
- read the canonical Team document explicitly so absence is not inferred from an error message
- document the small production operator contract in the runbook

## Diagnostic contract

- `401 { "status": "unauthorized" }` for missing or incorrect `CRON_SECRET`, with no readiness detail
- `503 { "status": "not_ready", "reason": "configuration" }` for runtime/configuration validation failures
- `503 { "status": "not_ready", "reason": "firebase_admin" }` for Admin initialization or Firestore request failures
- `503 { "status": "not_ready", "reason": "team_missing" }` when Firestore is reachable but the canonical Team is absent
- `200 { "status": "ready" }` when all stages pass

## Security and behavior

- timing-safe Bearer authentication is unchanged and runs before diagnostics
- responses and logs contain only fixed safe categories, never raw exceptions or environment values
- the endpoint remains read-only and makes no API-Football request
- lifecycle, ballot, bootstrap, and production data semantics are unchanged

## Verification

- focused health endpoint tests: 1 file / 6 tests passed
- lint passed
- strict typecheck passed
- changed-file Prettier check passed after formatting
- `git diff --check` passed

No production deployment was manually performed and no production data was changed.
