### PR TITLE
refactor: polish upcoming match presentation

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -70,7 +70,7 @@ Status badges are compact rectangular scoreboard labels with text and, when usef
 
 Use a small internal SVG set on a 16×16 grid with crisp geometric paths, `currentColor`, and no copied sprites. Decorative icons are hidden from assistive technology; meaningful icons need an accessible text equivalent. Do not add a broad icon dependency for a few concepts.
 
-Until an intentional provider/logo licensing strategy exists, team marks use safe initials, abbreviations, or simple themed blocks. Never invent or scrape official crests.
+Until an intentional provider/logo licensing strategy exists, team marks use original simplified shields with safe initials or abbreviations, flat traditional presentation colors, hard pixel-like geometry, and a neutral fallback for unknown teams. Team-name text must remain present; shields are supplementary and decorative. Never copy, invent, or scrape official crests.
 
 ## Rating controls
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,9 @@ a {
   letter-spacing: 0.025em;
   text-transform: uppercase;
 }
+.community-name {
+  text-transform: none;
+}
 .score-font {
   font-family: var(--font-score);
   font-weight: 400;
@@ -106,6 +109,51 @@ a {
   font-weight: 400;
   letter-spacing: 0.03em;
   text-transform: uppercase;
+}
+.team-badge {
+  position: relative;
+  display: block;
+  width: 3.25rem;
+  height: 3.75rem;
+  margin-inline: auto;
+  background: var(--game-shadow);
+  clip-path: polygon(8% 0, 92% 0, 100% 12%, 88% 76%, 50% 100%, 12% 76%, 0 12%);
+  filter: drop-shadow(2px 2px 0 var(--game-shadow));
+}
+.team-badge__field {
+  position: absolute;
+  inset: 2px;
+  background: var(--badge-primary);
+  clip-path: inherit;
+}
+.team-badge--stripe .team-badge__field {
+  background: linear-gradient(
+    90deg,
+    var(--badge-primary) 0 35%,
+    var(--badge-secondary) 35% 65%,
+    var(--badge-primary) 65% 100%
+  );
+}
+.team-badge--band .team-badge__field {
+  background: linear-gradient(
+    180deg,
+    var(--badge-secondary) 0 28%,
+    var(--badge-primary) 28% 100%
+  );
+}
+.team-badge__initials {
+  position: absolute;
+  top: 1.25rem;
+  left: 50%;
+  min-width: 1.75rem;
+  transform: translateX(-50%);
+  border: 1px solid var(--badge-secondary);
+  background: var(--badge-primary);
+  color: #fff;
+  font-family: var(--font-score);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  text-align: center;
 }
 .button-primary,
 .button-secondary,

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -13,7 +13,7 @@ const upcomingMatch = {
   competitionId: "competition-1",
   seasonId: "season-1",
   homeTeam: {
-    externalProviderId: "cartagines-provider-id",
+    externalProviderId: "820",
     name: "CS Cartagin\u00e9s",
   },
   awayTeam: { externalProviderId: "815", name: "CS Herediano" },

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -12,8 +12,11 @@ const upcomingMatch = {
   trackedTeamId: "club-sport-herediano",
   competitionId: "competition-1",
   seasonId: "season-1",
-  homeTeam: { externalProviderId: "815", name: "CS Herediano" },
-  awayTeam: { externalProviderId: "2000", name: "Opponent FC" },
+  homeTeam: {
+    externalProviderId: "cartagines-provider-id",
+    name: "CS Cartagin\u00e9s",
+  },
+  awayTeam: { externalProviderId: "815", name: "CS Herediano" },
   kickoffAt: "2026-08-30T23:00:00.000Z",
   status: "scheduled" as const,
   ratingState: "not_ready" as const,
@@ -30,6 +33,10 @@ describe("Home", () => {
     expect(
       screen.getByRole("heading", { name: "Club Sport Herediano" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Heredia por Media Calle")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Comunidad inicial de aficionados"),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
         name: "No hay una calificación activa",
@@ -42,6 +49,10 @@ describe("Home", () => {
 
   it("renders the same product UI in English", () => {
     render(<HomeContent locale="en" />);
+    expect(screen.getByText("Heredia por Media Calle")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Initial supporter community"),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "No active rating" }),
     ).toBeInTheDocument();
@@ -58,26 +69,29 @@ describe("Home", () => {
     expect(screen.queryByText("No active rating")).not.toBeInTheDocument();
   });
 
-  it("renders real upcoming match context without assuming the tracked Team is home", () => {
-    render(
-      <HomeContent
-        locale="es"
-        match={{
-          ...upcomingMatch,
-          homeTeam: { externalProviderId: "2000", name: "Opponent FC" },
-          awayTeam: { externalProviderId: "815", name: "CS Herediano" },
-        }}
-      />,
-    );
+  it("makes the real upcoming matchup primary without a repeated heading", () => {
+    render(<HomeContent locale="es" match={upcomingMatch} />);
     expect(
       screen.getByRole("heading", { name: "Pr\u00f3ximo partido" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Opponent FC")).toBeInTheDocument();
+    expect(screen.getAllByText("Pr\u00f3ximo partido")).toHaveLength(1);
+    expect(screen.getByText("CS Cartagin\u00e9s")).toBeInTheDocument();
     expect(screen.getByText("CS Herediano")).toBeInTheDocument();
     expect(screen.getByText("VS")).toBeInTheDocument();
+    expect(screen.getAllByTestId("team-badge")).toHaveLength(2);
   });
 
-  it("communicates live, preparing, and ready states with text", () => {
+  it("keeps the upcoming state localized in English", () => {
+    render(<HomeContent locale="en" match={upcomingMatch} />);
+    expect(
+      screen.getByRole("heading", { name: "Next match" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Next match")).toHaveLength(1);
+    expect(screen.getByText("CS Cartagin\u00e9s")).toBeInTheDocument();
+    expect(screen.getByText("CS Herediano")).toBeInTheDocument();
+  });
+
+  it("communicates live, preparing, ready, and results states with text", () => {
     const states = [
       {
         status: "live" as const,
@@ -93,6 +107,11 @@ describe("Home", () => {
         status: "finished" as const,
         ratingState: "rating_ready" as const,
         title: "The match is ready to rate",
+      },
+      {
+        status: "finished" as const,
+        ratingState: "rating_closed" as const,
+        title: "Community results",
       },
     ];
     for (const state of states) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { AppShell } from "@/components/app-shell";
 import { EmptyRatingState } from "@/components/empty-rating-state";
 import { MatchLifecyclePanel } from "@/components/match-lifecycle-panel";
 import { initialClub } from "@/config/club";
+import { communityName } from "@/config/community";
 import type { Match } from "@/domain/models";
 import type { Locale } from "@/i18n/config";
 import { getMessages } from "@/i18n/messages";
@@ -40,7 +41,7 @@ export function HomeContent({
     <AppShell locale={locale} messages={messages} theme={initialClub.theme}>
       <main id="main-content" className="page-shell py-7 sm:py-10">
         <section aria-labelledby="club-heading" className="mb-7">
-          <p className="eyebrow">{messages.home.communityEyebrow}</p>
+          <p className="eyebrow community-name break-words">{communityName}</p>
           <h1
             id="club-heading"
             className="mt-3 text-3xl font-extrabold leading-tight tracking-tight text-foreground sm:text-4xl"

--- a/src/components/match-lifecycle-panel.tsx
+++ b/src/components/match-lifecycle-panel.tsx
@@ -1,10 +1,13 @@
-import type { Match } from "@/domain/models";
 import Link from "next/link";
+
+import { getTeamBadgePresentation } from "@/config/team-badges";
+import type { Match } from "@/domain/models";
 import type { Locale } from "@/i18n/config";
 import { formatDate } from "@/i18n/format";
 import type { Messages } from "@/i18n/messages";
 
 import { BallotEntry } from "./ballot-entry";
+import { TeamBadge } from "./team-badge";
 
 export function MatchLifecyclePanel({
   match,
@@ -29,24 +32,32 @@ export function MatchLifecyclePanel({
         <span className="w-3/4 bg-brand" />
         <span className="w-1/4 bg-accent" />
       </div>
-      <div className="px-5 py-6 sm:px-7 sm:py-8">
-        <span className="status-badge">{state.label}</span>
-        <h2
-          id="match-status-heading"
-          className="score-font mt-5 text-2xl leading-tight text-foreground sm:text-3xl"
-        >
-          {state.title}
-        </h2>
-        <div className="mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-center">
-          <TeamName name={match.homeTeam.name} />
+      <div className="px-4 py-5 sm:px-7 sm:py-7">
+        {state.compactHeading ? (
+          <h2 id="match-status-heading" className="status-badge">
+            {state.label}
+          </h2>
+        ) : (
+          <>
+            <span className="status-badge">{state.label}</span>
+            <h2
+              id="match-status-heading"
+              className="score-font mt-4 text-2xl leading-tight text-foreground sm:text-3xl"
+            >
+              {state.title}
+            </h2>
+          </>
+        )}
+        <div className="mt-4 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 text-center sm:mt-5 sm:gap-4">
+          <TeamName team={match.homeTeam} />
           <span className="score-font text-2xl text-accent sm:text-3xl">
             {showScore
               ? `${match.score.home} - ${match.score.away}`
               : messages.versus}
           </span>
-          <TeamName name={match.awayTeam.name} />
+          <TeamName team={match.awayTeam} />
         </div>
-        <p className="mt-5 text-center text-sm leading-6 text-muted">
+        <p className="mt-4 text-center text-sm leading-6 text-muted">
           {formatDate(match.kickoffAt, locale, {
             dateStyle: "medium",
             timeStyle: "short",
@@ -82,23 +93,12 @@ function isVotingOpen(match: Match): boolean {
   );
 }
 
-function TeamName({ name }: { name: string }) {
-  const initials = name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0]?.toUpperCase())
-    .join("");
+function TeamName({ team }: { team: Match["homeTeam"] }) {
   return (
     <div className="min-w-0">
-      <span
-        aria-hidden="true"
-        className="score-font mx-auto flex h-10 w-10 items-center justify-center border-2 border-border bg-surface text-sm text-foreground"
-      >
-        {initials}
-      </span>
+      <TeamBadge presentation={getTeamBadgePresentation(team)} />
       <p className="mt-2 break-words text-sm font-semibold leading-5 text-foreground">
-        {name}
+        {team.name}
       </p>
     </div>
   );
@@ -113,6 +113,7 @@ function presentationState(
       label: messages.ready.label,
       title: messages.ready.title,
       description: messages.ready.description,
+      compactHeading: false,
     };
   }
   if (match.ratingState === "rating_closed") {
@@ -120,6 +121,7 @@ function presentationState(
       label: messages.results.label,
       title: messages.results.title,
       description: messages.results.description,
+      compactHeading: false,
     };
   }
   if (match.status === "live") {
@@ -127,6 +129,7 @@ function presentationState(
       label: messages.live.label,
       title: messages.live.title,
       description: messages.live.description,
+      compactHeading: false,
     };
   }
   if (match.status === "finished" || match.ratingState === "preparing_rating") {
@@ -134,11 +137,13 @@ function presentationState(
       label: messages.preparing.label,
       title: messages.preparing.title,
       description: messages.preparing.description,
+      compactHeading: false,
     };
   }
   return {
     label: messages.upcoming.label,
     title: messages.upcoming.title,
     description: messages.upcoming.description,
+    compactHeading: true,
   };
 }

--- a/src/components/team-badge.tsx
+++ b/src/components/team-badge.tsx
@@ -1,0 +1,30 @@
+import type { CSSProperties } from "react";
+
+import type { TeamBadgePresentation } from "@/config/team-badges";
+
+type BadgeStyle = CSSProperties & {
+  "--badge-primary": string;
+  "--badge-secondary": string;
+};
+
+export function TeamBadge({
+  presentation,
+}: {
+  presentation: TeamBadgePresentation;
+}) {
+  const style: BadgeStyle = {
+    "--badge-primary": presentation.primary,
+    "--badge-secondary": presentation.secondary,
+  };
+  return (
+    <span
+      aria-hidden="true"
+      className={`team-badge team-badge--${presentation.pattern}`}
+      data-testid="team-badge"
+      style={style}
+    >
+      <span className="team-badge__field" />
+      <span className="team-badge__initials">{presentation.abbreviation}</span>
+    </span>
+  );
+}

--- a/src/config/community.ts
+++ b/src/config/community.ts
@@ -1,0 +1,1 @@
+export const communityName = "Heredia por Media Calle";

--- a/src/config/team-badges.test.ts
+++ b/src/config/team-badges.test.ts
@@ -3,33 +3,28 @@ import { describe, expect, it } from "vitest";
 import { getTeamBadgePresentation } from "./team-badges";
 
 describe("team badge presentation", () => {
-  it("maps Herediano by stable provider identity", () => {
-    expect(
-      getTeamBadgePresentation({
-        externalProviderId: "815",
-        name: "A provider name change",
-      }),
-    ).toEqual({
-      abbreviation: "CH",
-      primary: "#b20d24",
-      secondary: "#f5c518",
-      pattern: "stripe",
-    });
-  });
-
-  it("maps Cartagin\u00e9s by stable provider identity despite a name change", () => {
-    expect(
-      getTeamBadgePresentation({
-        externalProviderId: "820",
-        name: "A renamed Cartagin\u00e9s display",
-      }),
-    ).toEqual({
-      abbreviation: "CC",
-      primary: "#174ea6",
-      secondary: "#f7f2e8",
-      pattern: "band",
-    });
-  });
+  it.each([
+    ["CS Herediano", "815", "CH", "#b20d24", "#f5c518", "stripe"],
+    ["Deportivo Saprissa", "816", "DS", "#6f2c91", "#f7f2e8", "band"],
+    ["Pérez Zeledón", "819", "PZ", "#1556a3", "#d4a72c", "stripe"],
+    ["CS Cartaginés", "820", "CC", "#174ea6", "#f7f2e8", "band"],
+    ["LD Alajuelense", "822", "LDA", "#c8102e", "#101113", "stripe"],
+    ["San Carlos", "823", "SC", "#c62828", "#174ea6", "stripe"],
+    ["Puntarenas FC", "2045", "PFC", "#f58220", "#101113", "band"],
+    ["Sporting San José", "2047", "SFC", "#171719", "#c9a227", "band"],
+    ["Escorpiones Belén", "17377", "EB", "#164fa3", "#f5c518", "stripe"],
+    ["Inter San Carlos", "24391", "ISC", "#177245", "#f5c518", "band"],
+  ] as const)(
+    "maps %s by stable provider ID %s",
+    (_team, id, abbreviation, primary, secondary, pattern) => {
+      expect(
+        getTeamBadgePresentation({
+          externalProviderId: id,
+          name: `Changed provider display ${id}`,
+        }),
+      ).toEqual({ abbreviation, primary, secondary, pattern });
+    },
+  );
 
   it("creates a neutral shield fallback for an unknown opponent", () => {
     expect(

--- a/src/config/team-badges.test.ts
+++ b/src/config/team-badges.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { getTeamBadgePresentation } from "./team-badges";
+
+describe("team badge presentation", () => {
+  it("maps Herediano by stable provider identity", () => {
+    expect(
+      getTeamBadgePresentation({
+        externalProviderId: "815",
+        name: "A provider name change",
+      }),
+    ).toEqual({
+      abbreviation: "CH",
+      primary: "#b20d24",
+      secondary: "#f5c518",
+      pattern: "stripe",
+    });
+  });
+
+  it("maps the current Cartagin\u00e9s fixture by an exact provider name", () => {
+    expect(
+      getTeamBadgePresentation({
+        externalProviderId: "cartagines-provider-id",
+        name: "CS Cartagin\u00e9s",
+      }),
+    ).toEqual({
+      abbreviation: "CC",
+      primary: "#174ea6",
+      secondary: "#f7f2e8",
+      pattern: "band",
+    });
+  });
+
+  it("creates a neutral shield fallback for an unknown opponent", () => {
+    expect(
+      getTeamBadgePresentation({
+        externalProviderId: "unknown",
+        name: "Opponent Football Club",
+      }),
+    ).toEqual({
+      abbreviation: "OF",
+      primary: "#363a40",
+      secondary: "#d5d0c7",
+      pattern: "stripe",
+    });
+  });
+});

--- a/src/config/team-badges.test.ts
+++ b/src/config/team-badges.test.ts
@@ -17,11 +17,11 @@ describe("team badge presentation", () => {
     });
   });
 
-  it("maps the current Cartagin\u00e9s fixture by an exact provider name", () => {
+  it("maps Cartagin\u00e9s by stable provider identity despite a name change", () => {
     expect(
       getTeamBadgePresentation({
-        externalProviderId: "cartagines-provider-id",
-        name: "CS Cartagin\u00e9s",
+        externalProviderId: "820",
+        name: "A renamed Cartagin\u00e9s display",
       }),
     ).toEqual({
       abbreviation: "CC",

--- a/src/config/team-badges.ts
+++ b/src/config/team-badges.ts
@@ -21,18 +21,11 @@ const CARTAGINES_BADGE: TeamBadgePresentation = {
   pattern: "band",
 };
 
-const CARTAGINES_NAMES = new Set([
-  "CS Cartaginés",
-  "CS Cartagines",
-  "Cartaginés",
-  "Cartagines",
-]);
-
 export function getTeamBadgePresentation(
   team: MatchTeamSnapshot,
 ): TeamBadgePresentation {
   if (team.externalProviderId === "815") return HEREDIANO_BADGE;
-  if (CARTAGINES_NAMES.has(team.name)) return CARTAGINES_BADGE;
+  if (team.externalProviderId === "820") return CARTAGINES_BADGE;
   return {
     abbreviation: abbreviation(team.name),
     primary: "#363a40",

--- a/src/config/team-badges.ts
+++ b/src/config/team-badges.ts
@@ -7,25 +7,75 @@ export interface TeamBadgePresentation {
   pattern: "stripe" | "band";
 }
 
-const HEREDIANO_BADGE: TeamBadgePresentation = {
-  abbreviation: "CH",
-  primary: "#b20d24",
-  secondary: "#f5c518",
-  pattern: "stripe",
-};
-
-const CARTAGINES_BADGE: TeamBadgePresentation = {
-  abbreviation: "CC",
-  primary: "#174ea6",
-  secondary: "#f7f2e8",
-  pattern: "band",
+// API-Football Primera División (league 162), season 2026.
+const CURATED_TEAM_BADGES: Readonly<Record<string, TeamBadgePresentation>> = {
+  "815": {
+    abbreviation: "CH",
+    primary: "#b20d24",
+    secondary: "#f5c518",
+    pattern: "stripe",
+  },
+  "816": {
+    abbreviation: "DS",
+    primary: "#6f2c91",
+    secondary: "#f7f2e8",
+    pattern: "band",
+  },
+  "819": {
+    abbreviation: "PZ",
+    primary: "#1556a3",
+    secondary: "#d4a72c",
+    pattern: "stripe",
+  },
+  "820": {
+    abbreviation: "CC",
+    primary: "#174ea6",
+    secondary: "#f7f2e8",
+    pattern: "band",
+  },
+  "822": {
+    abbreviation: "LDA",
+    primary: "#c8102e",
+    secondary: "#101113",
+    pattern: "stripe",
+  },
+  "823": {
+    abbreviation: "SC",
+    primary: "#c62828",
+    secondary: "#174ea6",
+    pattern: "stripe",
+  },
+  "2045": {
+    abbreviation: "PFC",
+    primary: "#f58220",
+    secondary: "#101113",
+    pattern: "band",
+  },
+  "2047": {
+    abbreviation: "SFC",
+    primary: "#171719",
+    secondary: "#c9a227",
+    pattern: "band",
+  },
+  "17377": {
+    abbreviation: "EB",
+    primary: "#164fa3",
+    secondary: "#f5c518",
+    pattern: "stripe",
+  },
+  "24391": {
+    abbreviation: "ISC",
+    primary: "#177245",
+    secondary: "#f5c518",
+    pattern: "band",
+  },
 };
 
 export function getTeamBadgePresentation(
   team: MatchTeamSnapshot,
 ): TeamBadgePresentation {
-  if (team.externalProviderId === "815") return HEREDIANO_BADGE;
-  if (team.externalProviderId === "820") return CARTAGINES_BADGE;
+  const curated = CURATED_TEAM_BADGES[team.externalProviderId];
+  if (curated) return curated;
   return {
     abbreviation: abbreviation(team.name),
     primary: "#363a40",

--- a/src/config/team-badges.ts
+++ b/src/config/team-badges.ts
@@ -1,0 +1,51 @@
+import type { MatchTeamSnapshot } from "@/domain/models";
+
+export interface TeamBadgePresentation {
+  abbreviation: string;
+  primary: string;
+  secondary: string;
+  pattern: "stripe" | "band";
+}
+
+const HEREDIANO_BADGE: TeamBadgePresentation = {
+  abbreviation: "CH",
+  primary: "#b20d24",
+  secondary: "#f5c518",
+  pattern: "stripe",
+};
+
+const CARTAGINES_BADGE: TeamBadgePresentation = {
+  abbreviation: "CC",
+  primary: "#174ea6",
+  secondary: "#f7f2e8",
+  pattern: "band",
+};
+
+const CARTAGINES_NAMES = new Set([
+  "CS Cartaginés",
+  "CS Cartagines",
+  "Cartaginés",
+  "Cartagines",
+]);
+
+export function getTeamBadgePresentation(
+  team: MatchTeamSnapshot,
+): TeamBadgePresentation {
+  if (team.externalProviderId === "815") return HEREDIANO_BADGE;
+  if (CARTAGINES_NAMES.has(team.name)) return CARTAGINES_BADGE;
+  return {
+    abbreviation: abbreviation(team.name),
+    primary: "#363a40",
+    secondary: "#d5d0c7",
+    pattern: "stripe",
+  };
+}
+
+function abbreviation(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  const initials = parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+  return initials || "FC";
+}

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -22,7 +22,6 @@ export const enMessages = {
     players: "Players",
   },
   home: {
-    communityEyebrow: "Initial supporter community",
     introduction:
       "Rate the players and head coach after the final whistle. The first rating window will appear here when a match is ready.",
     noActiveRating: {

--- a/src/i18n/messages/es.ts
+++ b/src/i18n/messages/es.ts
@@ -20,7 +20,6 @@ export const esMessages = {
     players: "Jugadores",
   },
   home: {
-    communityEyebrow: "Comunidad inicial de aficionados",
     introduction:
       "Califica a los jugadores y al director técnico después del pitazo final. La primera ventana de calificación aparecerá aquí cuando un partido esté listo.",
     noActiveRating: {


### PR DESCRIPTION
## Summary

- replace the translated supporter eyebrow with the canonical community name `Heredia por Media Calle`
- remove the redundant large upcoming-match heading and make the matchup the card's focal point
- replace square initials with an original reusable shield-style `TeamBadge`

## Community identity

`Heredia por Media Calle` now lives in shared presentation configuration as a non-translated proper noun. Spanish and English render the exact same name; the obsolete locale-specific community labels were removed.

## Team badges

- generic decorative shield component with crisp hard geometry and compact initials
- Herediano maps by stable provider Team ID to red/gold
- the current Cartaginés fixture maps by exact provider name to blue/white
- unknown teams derive safe initials and use a neutral charcoal/light shield
- official crests, provider logos, scraping, and persisted kit fields are not used

## UX

The upcoming status badge is now the semantic `h2`, avoiding duplicate “next match” content without breaking heading hierarchy. The compact fixture layout leads with home shield/name, `VS`, away shield/name, kickoff, and the unchanged voting-readiness callout. Other lifecycle titles remain intact.

Local hydrated browser QA passed in Spanish and English at 320, 360, 390, 430, and 1280px with no horizontal overflow, missing resources, hydration errors, or console errors. Shields remain 52×60px at desktop rather than scaling into hero artwork.

## Testing

- Home and badge presentation coverage includes shared community identity, obsolete-copy removal, single upcoming label, localized status, both team names/badges, curated mappings, neutral fallback, and all lifecycle presentation states
- full Vitest result: 26 files / 145 tests passed

## Verification

- `npm ci` passed
- `npm run format:check` passed
- `npm run lint` passed
- `npm run typecheck` passed
- `npm test` passed (26 files / 145 tests)
- `npm run build` passed
- final `npm run verify` passed
- `git diff --check` passed

## Scope

- no lifecycle behavior changes
- no Firebase configuration or persistence changes
- no API-Football/provider changes or calls
- no production data migration
- no manual production deployment or production data mutation
