### PR TITLE
fix: expose preparing rating readiness reason

### DIFF
--- a/src/app/api/internal/match-lifecycle/route.test.ts
+++ b/src/app/api/internal/match-lifecycle/route.test.ts
@@ -59,7 +59,8 @@ describe("POST /api/internal/match-lifecycle", () => {
       action: "preparing_rating",
       matchId: "match-1",
       providerRequests: 2,
-      reason: "Readiness incomplete: 10 rateable participants; head coach present.",
+      reason:
+        "Readiness incomplete: 10 rateable participants; head coach present.",
     });
     const response = await POST(
       new Request("http://local.test", {
@@ -72,7 +73,8 @@ describe("POST /api/internal/match-lifecycle", () => {
       action: "preparing_rating",
       matchId: "match-1",
       providerRequests: 2,
-      reason: "Readiness incomplete: 10 rateable participants; head coach present.",
+      reason:
+        "Readiness incomplete: 10 rateable participants; head coach present.",
     });
   });
 

--- a/src/app/api/internal/match-lifecycle/route.test.ts
+++ b/src/app/api/internal/match-lifecycle/route.test.ts
@@ -52,6 +52,30 @@ describe("POST /api/internal/match-lifecycle", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
+  it("returns the safe readiness reason while preparing rating", async () => {
+    vi.stubEnv("CRON_SECRET", "correct-secret");
+    vi.stubEnv("API_FOOTBALL_KEY", "provider-secret");
+    mocks.run.mockResolvedValue({
+      action: "preparing_rating",
+      matchId: "match-1",
+      providerRequests: 2,
+      reason: "Readiness incomplete: 10 rateable participants; head coach present.",
+    });
+    const response = await POST(
+      new Request("http://local.test", {
+        method: "POST",
+        headers: { authorization: "Bearer correct-secret" },
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      action: "preparing_rating",
+      matchId: "match-1",
+      providerRequests: 2,
+      reason: "Readiness incomplete: 10 rateable participants; head coach present.",
+    });
+  });
+
   it("fails safely when the API key is missing", async () => {
     vi.stubEnv("CRON_SECRET", "correct-secret");
     const response = await POST(

--- a/src/app/api/internal/match-lifecycle/route.ts
+++ b/src/app/api/internal/match-lifecycle/route.ts
@@ -33,12 +33,18 @@ export async function POST(request: Request) {
         action: result.action,
         matchId: result.matchId,
         providerRequests: result.providerRequests,
+        ...(result.action === "preparing_rating" && result.reason
+          ? { reason: result.reason }
+          : {}),
       });
     }
     const safeResult = {
       action: result.action,
       ...(result.matchId ? { matchId: result.matchId } : {}),
       providerRequests: result.providerRequests,
+      ...(result.action === "preparing_rating" && result.reason
+        ? { reason: result.reason }
+        : {}),
     };
     return json(safeResult, result.action === "retryable_error" ? 503 : 200);
   } catch {


### PR DESCRIPTION
## Summary
- return the existing safe `preparing_rating` readiness reason from the authenticated internal lifecycle endpoint
- include that same safe reason in lifecycle retry logging
- keep `retryable_error` provider details sanitized
- add focused route coverage

## Scope
This is observability-only. It does not change readiness rules, lifecycle transitions, voting timing, or provider polling.

## Docs
Canonical docs were reviewed. No source-of-truth update is needed because this hotfix does not change product/lifecycle/architecture invariants; it only exposes an already-existing safe diagnostic on an authenticated internal endpoint.

## Verification
CI required before merge.