### PR TITLE
feat: show live goal summaries

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -54,6 +54,8 @@ A sports-game panel contains a restrained accent rail, compact status/competitio
 
 Future scoreboard states may show `VS`, kickoff time, score, `FT`, live minute, or voting countdown using display typography. Do not fabricate match data to demonstrate the primitive in production, and do not introduce a component until a real product surface consumes it.
 
+Live confirmed-goal summaries stay inside the scoreboard panel and use one chronological row per event. Each row keeps two bounded halves around a visible center axis: home goals occupy and align toward the left half, while away goals occupy and align toward the right half. Stable Team identity determines placement; long scorer names wrap within their own half, and hidden text supplies explicit Team attribution so spatial position is never the only accessible cue. Finished-match summaries may retain their standalone post-match treatment.
+
 ## Buttons and motion
 
 - **Primary:** club-primary surface, high-contrast label, crisp border, hard shadow.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -10,6 +10,8 @@ Implemented now: a mobile-first shell with an original 16-bit sports-game visual
 
 While that trusted voting window is open, Home also offers a compact secondary WhatsApp action that shares the canonical rating deep link without voter, ballot, provider, or tracking data.
 
+While a tracked match is live, Home and match detail show a compact chronological summary of persisted confirmed goals when available. Home/away placement mirrors the scoreboard and reflects the latest lifecycle refresh rather than a real-time feed.
+
 At trusted close time, the same lifecycle creates one immutable aggregate summary and closes the rating state. Home and `/matches/{matchId}/results` then reveal community averages, total ballots, player-only co-MVPs, and the separate coach result. `/matches` keeps one relevant match in a featured position and provides compact, tabbed upcoming/recent archive browsing with lifecycle-aware actions, scores, and detail pages. `/players` and `/players/{playerId}` provide a durable supporter-rating catalog, team ranking, and per-match history derived only from those published closed results. Persisted provider fixtures remain useful even when Rating App never opened voting for them; confirmed provider goal events appear as a focused scorer/minute summary when available.
 
 Not implemented now: cloud Team administration, identity-provider linking, season leaderboards, notifications, or administration. Individual ballot data remains private at all times, and aggregates remain unavailable before close.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,6 +65,7 @@ export function HomeContent({
             match={match}
             locale={locale}
             messages={messages.home.matchLifecycle}
+            goalMessages={messages.matches}
           />
         )}
       </main>

--- a/src/components/goal-summary.tsx
+++ b/src/components/goal-summary.tsx
@@ -1,0 +1,174 @@
+import type { Match, MatchGoalEvent } from "@/domain/models";
+import type { Messages } from "@/i18n/messages";
+
+type GoalMessages = Pick<
+  Messages["matches"],
+  "goal" | "goalByTeam" | "goals" | "opponentGoal" | "trackedTeamGoal"
+>;
+
+export function GoalSummary({
+  match,
+  messages,
+  compact = false,
+}: {
+  match: Match;
+  messages: GoalMessages;
+  compact?: boolean;
+}) {
+  const events = match.goalEvents ?? [];
+  if (events.length === 0) return null;
+  const trackedExternalId = match.trackedTeamExternalProviderId;
+  if (compact) {
+    const orientedEvents = chronologicalGoals(events).flatMap(
+      ({ event, originalIndex }) => {
+        const home = event.externalTeamId === match.homeTeam.externalProviderId;
+        const away = event.externalTeamId === match.awayTeam.externalProviderId;
+        if (home === away) return [];
+        return [
+          {
+            event,
+            originalIndex,
+            side: home ? ("home" as const) : ("away" as const),
+            teamName: home ? match.homeTeam.name : match.awayTeam.name,
+          },
+        ];
+      },
+    );
+    if (orientedEvents.length === 0) return null;
+    return (
+      <section aria-label={messages.goals} className="mt-4">
+        <h2 className="score-font text-sm text-muted">{messages.goals}</h2>
+        <ol className="mt-2 space-y-2">
+          {orientedEvents.map(({ event, originalIndex, side, teamName }) => {
+            const scorerName =
+              typeof event.scorerName === "string"
+                ? event.scorerName.trim()
+                : "";
+            const visibleName = scorerName || teamName;
+            const minute = formatGoalMinute(event);
+            const teamAnnouncement = messages.goalByTeam.replace(
+              "{team}",
+              teamName,
+            );
+            const announcement = scorerName
+              ? `${teamAnnouncement}, ${scorerName}, ${minute}`
+              : `${teamAnnouncement}, ${minute}`;
+            return (
+              <li
+                key={`${event.externalTeamId}-${event.externalPlayerId}-${event.elapsed}-${event.extra ?? 0}-${originalIndex}`}
+                aria-label={announcement}
+                data-goal-side={side}
+                className="grid grid-cols-[minmax(0,1fr)_1px_minmax(0,1fr)] text-sm"
+              >
+                {side === "home" ? (
+                  <GoalHalf side="home" name={visibleName} minute={minute} />
+                ) : (
+                  <span data-goal-half="home" aria-hidden="true" />
+                )}
+                <span aria-hidden="true" className="bg-border" />
+                {side === "away" ? (
+                  <GoalHalf side="away" name={visibleName} minute={minute} />
+                ) : (
+                  <span data-goal-half="away" aria-hidden="true" />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="goal-summary-heading" className="card mt-6 p-5">
+      <h2 id="goal-summary-heading" className="score-font text-xl">
+        {messages.goals}
+      </h2>
+      <ol className="mt-3 space-y-2">
+        {events.map((event, originalIndex) => {
+          const tracked =
+            trackedExternalId !== undefined &&
+            event.externalTeamId === trackedExternalId;
+          const association =
+            trackedExternalId === undefined
+              ? messages.goal
+              : tracked
+                ? messages.trackedTeamGoal
+                : messages.opponentGoal;
+          return (
+            <li
+              key={`${event.externalTeamId}-${event.externalPlayerId}-${event.elapsed}-${event.extra ?? 0}-${originalIndex}`}
+              className="game-inset flex items-center gap-3 p-3"
+            >
+              <span aria-hidden="true">⚽</span>
+              <span className="min-w-0 flex-1 break-words font-bold">
+                {event.scorerName}
+              </span>
+              <span className="score-font text-accent">
+                {formatGoalMinute(event)}
+              </span>
+              <span className="sr-only">{association}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+export function formatGoalMinute(event: MatchGoalEvent): string {
+  return `${event.elapsed}${event.extra && event.extra > 0 ? `+${event.extra}` : ""}'`;
+}
+
+function chronologicalGoals(events: MatchGoalEvent[]) {
+  return events
+    .map((event, originalIndex) => ({ event, originalIndex }))
+    .filter(
+      ({ event }) =>
+        typeof event.externalTeamId === "string" &&
+        Number.isFinite(event.elapsed) &&
+        event.elapsed >= 0,
+    )
+    .sort(
+      (left, right) =>
+        left.event.elapsed - right.event.elapsed ||
+        (left.event.extra ?? 0) - (right.event.extra ?? 0) ||
+        left.originalIndex - right.originalIndex,
+    );
+}
+
+function GoalHalf({
+  side,
+  name,
+  minute,
+}: {
+  side: "home" | "away";
+  name: string;
+  minute: string;
+}) {
+  return (
+    <span
+      data-goal-half={side}
+      aria-hidden="true"
+      className={`game-inset flex min-w-0 items-center gap-1 px-2 py-2 ${
+        side === "home"
+          ? "justify-end border-r-0 text-right"
+          : "justify-start border-l-0 text-left"
+      }`}
+    >
+      {side === "home" ? (
+        <>
+          <span className="min-w-0 break-words font-bold">{name}</span>
+          <span>·</span>
+          <span className="score-font shrink-0 text-accent">{minute}</span>
+        </>
+      ) : (
+        <>
+          <span className="score-font shrink-0 text-accent">{minute}</span>
+          <span>·</span>
+          <span className="min-w-0 break-words font-bold">{name}</span>
+        </>
+      )}
+    </span>
+  );
+}

--- a/src/components/match-archive.test.tsx
+++ b/src/components/match-archive.test.tsx
@@ -7,13 +7,9 @@ import type { Match } from "@/domain/models";
 import { getMessages } from "@/i18n/messages";
 import { getBallotStatus } from "@/lib/firebase/ballot-client";
 
-import {
-  formatGoalMinute,
-  GoalSummary,
-  MatchArchiveView,
-  MatchCard,
-} from "./match-archive";
+import { MatchArchiveView, MatchCard } from "./match-archive";
 import { MatchDetail } from "./match-detail";
+import { formatGoalMinute, GoalSummary } from "./goal-summary";
 
 vi.mock("@/lib/firebase/ballot-client", () => ({
   getBallotStatus: vi.fn(),
@@ -362,6 +358,152 @@ describe("Partidos presentation", () => {
     expect(screen.getByRole("listitem")).toHaveTextContent("Goal");
     expect(screen.getByRole("listitem")).not.toHaveTextContent(
       "Herediano goal",
+    );
+  });
+
+  it("reuses the compact persisted-goal summary for a live match detail", () => {
+    const value = match({
+      status: "live",
+      score: { home: 1, away: 0 },
+      goalEvents: [
+        {
+          externalTeamId: "815",
+          externalPlayerId: "1",
+          scorerName: "Live scorer",
+          elapsed: 45,
+          extra: 2,
+          kind: "normal",
+        },
+      ],
+    });
+
+    render(
+      <MatchDetail
+        item={item(value)}
+        locale="en"
+        messages={messages}
+        ballotMessages={ballotMessages}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByText("1 - 0")).toBeInTheDocument();
+    const goalItem = within(
+      screen.getByRole("region", { name: "Confirmed goals" }),
+    ).getByRole("listitem");
+    expect(goalItem).toHaveTextContent("Live scorer·45+2'");
+    expect(goalItem).toHaveAttribute("data-goal-side", "home");
+    expect(goalItem).toHaveAccessibleName(
+      "Goal by CS Herediano, Live scorer, 45+2'",
+    );
+  });
+
+  it.each([
+    ["scheduled", { status: "scheduled", ratingState: "not_ready" }],
+    ["preparing", { status: "finished", ratingState: "preparing_rating" }],
+  ] as const)(
+    "does not render a live goal summary for %s detail",
+    (_name, state) => {
+      render(
+        <MatchDetail
+          item={item(match(state))}
+          locale="en"
+          messages={messages}
+          ballotMessages={ballotMessages}
+          now={now}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("region", { name: "Confirmed goals" }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("keeps the finished detail goal presentation in its standalone card", () => {
+    render(
+      <MatchDetail
+        item={item(
+          match({
+            status: "finished",
+            goalEvents: [
+              {
+                externalTeamId: "815",
+                externalPlayerId: "1",
+                scorerName: "Finished scorer",
+                elapsed: 70,
+                kind: "normal",
+              },
+            ],
+          }),
+        )}
+        locale="en"
+        messages={messages}
+        ballotMessages={ballotMessages}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByRole("region", { name: "Confirmed goals" })).toHaveClass(
+      "card",
+    );
+    expect(screen.getByRole("listitem")).toHaveTextContent(
+      "Finished scorer70'",
+    );
+  });
+
+  it("uses stable team identity for side placement and a safe scorer fallback", () => {
+    const longName =
+      "A deliberately long opponent scorer name that must wrap inside one half";
+    const value = match({
+      status: "live",
+      goalEvents: [
+        {
+          externalTeamId: "820",
+          externalPlayerId: "1",
+          scorerName: "CS Herediano",
+          elapsed: 12,
+          kind: "normal",
+        },
+        {
+          externalTeamId: "815",
+          externalPlayerId: "",
+          scorerName: "",
+          elapsed: 20,
+          kind: "other",
+        },
+        {
+          externalTeamId: "820",
+          externalPlayerId: "2",
+          scorerName: longName,
+          elapsed: 30,
+          kind: "normal",
+        },
+        {
+          externalTeamId: "unknown",
+          externalPlayerId: "3",
+          scorerName: "Unknown side",
+          elapsed: 40,
+          kind: "normal",
+        },
+      ],
+    });
+
+    render(<GoalSummary match={value} messages={messages} compact />);
+
+    const goals = screen.getAllByRole("listitem");
+    expect(goals).toHaveLength(3);
+    expect(goals[0]).toHaveAttribute("data-goal-side", "away");
+    expect(goals[0]).toHaveTextContent("12'·CS Herediano");
+    expect(goals[1]).toHaveAttribute("data-goal-side", "home");
+    expect(goals[1]).toHaveTextContent("CS Herediano·20'");
+    expect(goals[1]).toHaveAccessibleName("Goal by CS Herediano, 20'");
+    expect(goals[2]).toHaveAttribute("data-goal-side", "away");
+    expect(screen.queryByText("Unknown side")).not.toBeInTheDocument();
+    expect(screen.getByText(longName)).toHaveClass("min-w-0", "break-words");
+    expect(screen.getByText(longName).parentElement).toHaveAttribute(
+      "data-goal-half",
+      "away",
     );
   });
 });

--- a/src/components/match-archive.tsx
+++ b/src/components/match-archive.tsx
@@ -8,7 +8,7 @@ import type {
   MatchArchiveItem,
 } from "@/application/match-archive";
 import { getTeamBadgePresentation } from "@/config/team-badges";
-import type { Match, MatchGoalEvent } from "@/domain/models";
+import type { Match } from "@/domain/models";
 import type { Locale } from "@/i18n/config";
 import { formatDate } from "@/i18n/format";
 import type { Messages } from "@/i18n/messages";
@@ -352,55 +352,4 @@ function Team({ team }: { team: Match["homeTeam"] }) {
       <p className="mt-2 break-words text-sm font-bold">{team.name}</p>
     </div>
   );
-}
-
-export function GoalSummary({
-  match,
-  messages,
-}: {
-  match: Match;
-  messages: MatchMessages;
-}) {
-  const events = match.goalEvents ?? [];
-  if (events.length === 0) return null;
-  const trackedExternalId = match.trackedTeamExternalProviderId;
-  return (
-    <section aria-labelledby="goal-summary-heading" className="card mt-6 p-5">
-      <h2 id="goal-summary-heading" className="score-font text-xl">
-        {messages.goals}
-      </h2>
-      <ol className="mt-3 space-y-2">
-        {events.map((event, index) => {
-          const tracked =
-            trackedExternalId !== undefined &&
-            event.externalTeamId === trackedExternalId;
-          const association =
-            trackedExternalId === undefined
-              ? messages.goal
-              : tracked
-                ? messages.trackedTeamGoal
-                : messages.opponentGoal;
-          return (
-            <li
-              key={`${event.externalTeamId}-${event.externalPlayerId}-${event.elapsed}-${event.extra ?? 0}-${index}`}
-              className="game-inset flex items-center gap-3 p-3"
-            >
-              <span aria-hidden="true">⚽</span>
-              <span className="min-w-0 flex-1 break-words font-bold">
-                {event.scorerName}
-              </span>
-              <span className="score-font text-accent">
-                {formatGoalMinute(event)}
-              </span>
-              <span className="sr-only">{association}</span>
-            </li>
-          );
-        })}
-      </ol>
-    </section>
-  );
-}
-
-export function formatGoalMinute(event: MatchGoalEvent): string {
-  return `${event.elapsed}${event.extra && event.extra > 0 ? `+${event.extra}` : ""}'`;
 }

--- a/src/components/match-detail.tsx
+++ b/src/components/match-detail.tsx
@@ -6,7 +6,8 @@ import { formatDate } from "@/i18n/format";
 import type { Messages } from "@/i18n/messages";
 
 import { BallotEntry } from "./ballot-entry";
-import { GoalSummary, Scoreboard } from "./match-archive";
+import { GoalSummary } from "./goal-summary";
+import { Scoreboard } from "./match-archive";
 import { matchPresentation } from "./match-presentation";
 
 export function MatchDetail({
@@ -41,6 +42,9 @@ export function MatchDetail({
             </p>
           ) : null}
           <Scoreboard match={item.match} />
+          {item.match.status === "live" ? (
+            <GoalSummary match={item.match} messages={messages} compact />
+          ) : null}
           <p className="mt-4 text-center text-sm text-muted">
             {formatDate(item.match.kickoffAt, locale, {
               dateStyle: "full",
@@ -62,7 +66,9 @@ export function MatchDetail({
           ) : null}
         </div>
       </article>
-      <GoalSummary match={item.match} messages={messages} />
+      {item.match.status === "finished" ? (
+        <GoalSummary match={item.match} messages={messages} />
+      ) : null}
       <Link
         href="/matches"
         className="button-secondary mt-6 inline-flex min-h-11 items-center px-4 py-3 font-bold"

--- a/src/components/match-lifecycle-panel.test.tsx
+++ b/src/components/match-lifecycle-panel.test.tsx
@@ -30,6 +30,7 @@ describe("Home WhatsApp rating share", () => {
         })}
         locale="es"
         messages={messages}
+        goalMessages={getMessages("es").matches}
       />,
     );
 
@@ -84,6 +85,7 @@ describe("Home WhatsApp rating share", () => {
         match={match(state)}
         locale="es"
         messages={messages}
+        goalMessages={getMessages("es").matches}
       />,
     );
 
@@ -91,7 +93,81 @@ describe("Home WhatsApp rating share", () => {
       screen.queryByRole("link", { name: "Compartir votación por WhatsApp" }),
     ).not.toBeInTheDocument();
   });
+
+  it("renders persisted live goals chronologically without changing the score", () => {
+    render(
+      <MatchLifecyclePanel
+        match={match({
+          status: "live",
+          score: { home: 2, away: 1 },
+          goalEvents: [
+            goal({ scorerName: "Late scorer", elapsed: 54 }),
+            goal({
+              externalTeamId: "820",
+              scorerName: "First scorer",
+              elapsed: 18,
+            }),
+            goal({
+              externalTeamId: "820",
+              scorerName: "Second at 54",
+              elapsed: 54,
+            }),
+          ],
+        })}
+        locale="es"
+        messages={messages}
+        goalMessages={getMessages("es").matches}
+      />,
+    );
+
+    expect(screen.getByText("2 - 1")).toBeInTheDocument();
+    const goals = screen.getAllByRole("listitem");
+    expect(goals[0]).toHaveTextContent("18'·First scorer");
+    expect(goals[1]).toHaveTextContent("Late scorer·54'");
+    expect(goals[2]).toHaveTextContent("54'·Second at 54");
+    expect(goals[0]).toHaveAttribute("data-goal-side", "away");
+    expect(goals[1]).toHaveAttribute("data-goal-side", "home");
+    expect(goals[2]).toHaveAttribute("data-goal-side", "away");
+    expect(goals[1].querySelector('[data-goal-half="home"]')).toHaveClass(
+      "justify-end",
+      "text-right",
+    );
+    expect(goals[0].querySelector('[data-goal-half="away"]')).toHaveClass(
+      "justify-start",
+      "text-left",
+    );
+    expect(goals[0]).toHaveAccessibleName(
+      "Gol de CS Cartaginés, First scorer, 18'",
+    );
+  });
+
+  it("renders no empty goal section for a scoreless live match", () => {
+    render(
+      <MatchLifecyclePanel
+        match={match({ status: "live", score: { home: 0, away: 0 } })}
+        locale="es"
+        messages={messages}
+        goalMessages={getMessages("es").matches}
+      />,
+    );
+
+    expect(screen.getByText("0 - 0")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Goles confirmados" }),
+    ).not.toBeInTheDocument();
+  });
 });
+
+function goal(overrides: Partial<NonNullable<Match["goalEvents"]>[number]>) {
+  return {
+    externalTeamId: "815",
+    externalPlayerId: "player",
+    scorerName: "Scorer",
+    elapsed: 10,
+    kind: "normal" as const,
+    ...overrides,
+  };
+}
 
 function match(overrides: Partial<Match> = {}): Match {
   return {

--- a/src/components/match-lifecycle-panel.tsx
+++ b/src/components/match-lifecycle-panel.tsx
@@ -8,16 +8,19 @@ import { formatDate } from "@/i18n/format";
 import type { Messages } from "@/i18n/messages";
 
 import { BallotEntry } from "./ballot-entry";
+import { GoalSummary } from "./goal-summary";
 import { TeamBadge } from "./team-badge";
 
 export function MatchLifecyclePanel({
   match,
   locale,
   messages,
+  goalMessages,
 }: {
   match: Match;
   locale: Locale;
   messages: Messages["home"]["matchLifecycle"];
+  goalMessages: Messages["matches"];
 }) {
   const state = presentationState(match, messages);
   const showScore =
@@ -58,6 +61,9 @@ export function MatchLifecyclePanel({
           </span>
           <TeamName team={match.awayTeam} />
         </div>
+        {match.status === "live" ? (
+          <GoalSummary match={match} messages={goalMessages} compact />
+        ) : null}
         <p className="mt-4 text-center text-sm leading-6 text-muted">
           {formatDate(match.kickoffAt, locale, {
             dateStyle: "medium",

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -139,6 +139,7 @@ export const enMessages = {
     back: "Back to matches",
     goals: "Confirmed goals",
     goal: "Goal",
+    goalByTeam: "Goal by {team}",
     trackedTeamGoal: "Herediano goal",
     opponentGoal: "Opponent goal",
     liveDescription:

--- a/src/i18n/messages/es.ts
+++ b/src/i18n/messages/es.ts
@@ -140,6 +140,7 @@ export const esMessages = {
     back: "Volver a partidos",
     goals: "Goles confirmados",
     goal: "Gol",
+    goalByTeam: "Gol de {team}",
     trackedTeamGoal: "Gol de Herediano",
     opponentGoal: "Gol del rival",
     liveDescription:


### PR DESCRIPTION
Closes #42. Adds one reusable, persisted-data-only live goal summary to Home and match detail, with chronological center-axis home/away placement keyed by stable provider Team IDs, safe unknown-team omission, scorer fallback, accessible Team attribution, and bounded mobile wrapping. Finished-match detail presentation remains unchanged. Updates PRODUCT.md and DESIGN_SYSTEM.md; ARCHITECTURE.md and PRODUCTION_RUNBOOK.md remain unchanged because persistence and operations did not change. Verification: npm run verify (39 files, 253 tests, production build); npm run test:firebase (7 files, 47 tests); git diff --check; emulated 320px layout inspection.