### PR TITLE
fix: add Firestore index for participant readiness

### DIFF
--- a/PRODUCTION_RUNBOOK.md
+++ b/PRODUCTION_RUNBOOK.md
@@ -55,7 +55,7 @@ No Firebase or API-Football credential belongs in GitHub for this workflow.
 6. From a clean reviewed commit, deploy with an explicit target: `firebase deploy --only firestore:rules,firestore:indexes --project <exact-production-project-id>`. Never rely on `.firebaserc`, whose default remains the safe demo project.
 7. Verify rules: only `teams/{teamId}` is public-readable; all client writes and all other reads, including ballots and results, are denied.
 
-Jugadores V1 adds the tracked-Team/kickoff match-history composite index and participant collection-group single-field index declared in `firestore.indexes.json`; deploy them with the existing explicit `firestore:indexes` command before releasing player pages.
+Jugadores V1 adds the tracked-Team/kickoff match-history composite index and participant collection-group single-field index declared in `firestore.indexes.json`. Lifecycle readiness additionally requires the collection-scoped `participants(participated, teamId)` composite index used by `countRateableParticipants()`. Deploy all declared indexes with the explicit `firestore:indexes` command before relying on player pages or post-FT voting readiness in production.
 
 ## Safe deployment and bootstrap order
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "trackedTeamId", "order": "ASCENDING" },
         { "fieldPath": "kickoffAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "participants",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participated", "order": "ASCENDING" },
+        { "fieldPath": "teamId", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
Closes #50

## Root cause

Production post-FT reconciliation for fixture `1551678` reached a usable lineup and persisted trusted match context, but `AdminFootballSyncStore.countRateableParticipants()` failed with Firestore `FAILED_PRECONDITION` because the collection query combines `teamId == ...` and `participated == true` without the required composite index.

## Fix

- Added a collection-scoped composite index for `participants` on:
  - `participated` ASCENDING
  - `teamId` ASCENDING
- Preserved the existing matches composite index and participant collection-group single-field override.
- Updated `PRODUCTION_RUNBOOK.md` so post-FT readiness explicitly requires this deployed index.

No lifecycle, readiness, eligibility, provider, Firebase rules, schema, or voting-window behavior changed.

## Production follow-up

After merge, deploy `firestore:indexes` explicitly to `rating-app-prod-8b7df`, wait until the index is ready, then observe/rerun lifecycle for `match-2de44c3c058bd3defcadd69e` and confirm it progresses beyond the Firestore precondition failure.
