### PR TITLE
fix: simplify submitted ballot state

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -82,7 +82,7 @@ Until an intentional provider/logo licensing strategy exists, team marks use ori
 
 Ratings use a five-column grid of discrete values `1` through `10`, not a precision slider. Each player and the head coach has a labeled fieldset; every value is a 44px-or-larger button with `aria-pressed`, keyboard operation, high contrast, and an unmistakable club-secondary selected state. The complete-count and sticky submission action remain visible on narrow screens without covering the final control.
 
-Submission uses one focused confirmation dialog because ballots are immutable. It explains that ratings cannot be changed, traps keyboard focus, supports Escape/cancel, and restores focus to the triggering button. Recoverable errors preserve every selected rating. Submitted, closed, not-open, and unavailable states use explicit localized text and never reveal individual or aggregate results.
+Submission uses one focused confirmation dialog because ballots are immutable. It explains that ratings cannot be changed, traps keyboard focus, supports Escape/cancel, and restores focus to the triggering button. Recoverable errors preserve every selected rating. On voting-entry surfaces, a submitted ballot becomes one compact, non-interactive inline success status with a decorative check; it has no button states, shadow, focus stop, or redundant explanation, and may sit beside a real sharing action. Closed, not-open, and unavailable states use explicit localized text. These states never reveal individual or aggregate results.
 
 ## Match results
 

--- a/src/components/ballot-entry.test.tsx
+++ b/src/components/ballot-entry.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getMessages } from "@/i18n/messages";
+import { getBallotStatus } from "@/lib/firebase/ballot-client";
+
+import { BallotEntry } from "./ballot-entry";
+
+vi.mock("@/lib/firebase/ballot-client", () => ({
+  getBallotStatus: vi.fn(),
+}));
+
+const shareHref = "https://wa.me/?text=rating";
+
+describe("BallotEntry submitted state", () => {
+  beforeEach(() => {
+    vi.mocked(getBallotStatus).mockResolvedValue("submitted");
+  });
+
+  it.each([
+    ["es" as const, "Calificación enviada", "Compartir votación por WhatsApp"],
+    ["en" as const, "Rating submitted", "Share voting via WhatsApp"],
+  ])(
+    "renders a localized non-interactive status beside WhatsApp in %s",
+    async (locale, submittedLabel, shareLabel) => {
+      render(
+        <BallotEntry
+          matchId="match-1"
+          messages={getMessages(locale).home.matchLifecycle.ready}
+          shareHref={shareHref}
+        />,
+      );
+
+      const status = await screen.findByRole("status");
+      const share = screen.getByRole("link", { name: shareLabel });
+
+      expect(status).toHaveTextContent(submittedLabel);
+      expect(status).not.toHaveAttribute("tabindex");
+      expect(status.querySelector("svg")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+      expect(
+        screen.queryByRole("button", { name: submittedLabel }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: submittedLabel }),
+      ).not.toBeInTheDocument();
+      expect(share).toHaveAttribute("href", shareHref);
+      expect(share).toHaveAttribute("aria-label", shareLabel);
+      expect(share).toHaveAttribute("title", shareLabel);
+      expect(status.parentElement?.parentElement).toHaveClass(
+        "max-w-full",
+        "flex-wrap",
+      );
+      expect(status).toHaveClass("max-w-full");
+      expect(share).toHaveClass("shrink-0");
+    },
+  );
+
+  it("keeps the normal rating action for a voter who has not submitted", async () => {
+    vi.mocked(getBallotStatus).mockResolvedValue("available");
+    render(
+      <BallotEntry
+        matchId="match-1"
+        messages={getMessages("es").home.matchLifecycle.ready}
+        shareHref={shareHref}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("link", { name: "Calificar partido" }),
+    ).toHaveAttribute("href", "/matches/match-1/rate");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ballot-entry.tsx
+++ b/src/components/ballot-entry.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import type { Messages } from "@/i18n/messages";
 import { getBallotStatus } from "@/lib/firebase/ballot-client";
 
-import { WhatsAppIcon } from "./game-icons";
+import { CheckIcon, WhatsAppIcon } from "./game-icons";
 
 export function BallotEntry({
   matchId,
@@ -44,15 +44,13 @@ export function BallotEntry({
   }
   if (state === "submitted") {
     return actionRow(
-      <div
-        className={`game-inset ${compact ? `${shareHref ? "" : "mt-3"} px-3 py-2` : `${shareHref ? "" : "mt-5"} p-3`}`}
+      <span
+        className={`score-font inline-flex min-h-8 max-w-full items-center gap-2 border border-success/50 bg-success/10 px-2 py-1 text-[0.6875rem] uppercase tracking-[0.03em] text-success ${shareHref ? "" : compact ? "mt-3" : "mt-5"}`}
         role="status"
       >
-        <p className="status-badge">{messages.submitted}</p>
-        <p className="mt-1 text-sm text-muted">
-          {messages.submittedDescription}
-        </p>
-      </div>,
+        <CheckIcon aria-hidden="true" className="shrink-0" />
+        <span>{messages.submitted}</span>
+      </span>,
       shareHref,
       messages.share,
     );
@@ -90,7 +88,7 @@ function actionRow(
   if (!shareHref) return content;
 
   return (
-    <div className="mt-5 flex items-center gap-3">
+    <div className="mt-5 flex max-w-full flex-wrap items-center gap-3">
       <div className="min-w-0">{content}</div>
       {shareHref ? (
         <a

--- a/src/components/game-icons.tsx
+++ b/src/components/game-icons.tsx
@@ -32,6 +32,21 @@ export function StatusPanelIcon(props: GameIconProps) {
   );
 }
 
+export function CheckIcon(props: GameIconProps) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
+      fill="currentColor"
+      shapeRendering="crispEdges"
+      {...props}
+    >
+      <path d="M2 7h2v2h2v2h2V9h2V7h2V5h2v4h-2v2h-2v2H6v-2H4V9H2z" />
+    </svg>
+  );
+}
+
 export function WhatsAppIcon(props: GameIconProps) {
   return (
     <svg

--- a/src/components/match-archive.test.tsx
+++ b/src/components/match-archive.test.tsx
@@ -90,8 +90,8 @@ describe("Partidos presentation", () => {
 
     expect(await screen.findByText("Rating submitted")).toBeInTheDocument();
     expect(
-      screen.getByText("Your rating has already been recorded."),
-    ).toBeInTheDocument();
+      screen.queryByText("Your rating has already been recorded."),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Rate match" }),
     ).not.toBeInTheDocument();
@@ -132,7 +132,7 @@ describe("Partidos presentation", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps a submitted secondary card compact and non-actionable", async () => {
+  it("keeps a submitted secondary status compact and non-actionable", async () => {
     vi.mocked(getBallotStatus).mockResolvedValue("submitted");
     const ready = item(
       match({
@@ -154,7 +154,9 @@ describe("Partidos presentation", () => {
       />,
     );
 
-    expect(await screen.findByText("Rating submitted")).toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Rating submitted",
+    );
     expect(
       screen.queryByRole("link", { name: "Rate match" }),
     ).not.toBeInTheDocument();

--- a/src/components/match-lifecycle-panel.test.tsx
+++ b/src/components/match-lifecycle-panel.test.tsx
@@ -52,6 +52,32 @@ describe("Home WhatsApp rating share", () => {
     );
   });
 
+  it("keeps WhatsApp actionable beside a submitted non-interactive status", async () => {
+    vi.mocked(getBallotStatus).mockResolvedValue("submitted");
+    render(
+      <MatchLifecyclePanel
+        match={match({
+          ratingState: "rating_ready",
+          status: "finished",
+          votingOpensAt: new Date(now - 60_000).toISOString(),
+          votingClosesAt: new Date(now + 60_000).toISOString(),
+        })}
+        locale="es"
+        messages={messages}
+        goalMessages={getMessages("es").matches}
+      />,
+    );
+
+    const status = await screen.findByRole("status");
+    expect(status).toHaveTextContent("Calificación enviada");
+    expect(
+      screen.getByRole("link", { name: "Compartir votación por WhatsApp" }),
+    ).toHaveAttribute("title", "Compartir votación por WhatsApp");
+    expect(
+      screen.queryByRole("link", { name: "Calificar partido" }),
+    ).not.toBeInTheDocument();
+  });
+
   it.each([
     [
       "expired",

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -89,7 +89,6 @@ export const enMessages = {
         action: "Rate match",
         share: "Share voting via WhatsApp",
         submitted: "Rating submitted",
-        submittedDescription: "Your rating has already been recorded.",
         checking: "Preparing your session...",
         sessionError: "We couldn't prepare your session. Try again.",
       },

--- a/src/i18n/messages/es.ts
+++ b/src/i18n/messages/es.ts
@@ -89,7 +89,6 @@ export const esMessages = {
         action: "Calificar partido",
         share: "Compartir votación por WhatsApp",
         submitted: "Calificaci\u00f3n enviada",
-        submittedDescription: "Tu calificaci\u00f3n ya fue registrada.",
         checking: "Preparando tu sesi\u00f3n...",
         sessionError: "No pudimos preparar tu sesi\u00f3n. Intenta de nuevo.",
       },


### PR DESCRIPTION
Closes #52

## UX problem
The submitted ballot treatment used a nested inset card, gold status badge, and redundant explanation. That visual weight competed with the active-match hierarchy and made a completed personal state resemble another call to action.

## Implementation
- Replaces the heavy submitted card with one compact inline semantic-success status and a crisp decorative check icon.
- Removes the redundant ready-state confirmation sentence in Spanish and English.
- Keeps the existing WhatsApp link beside the status as the only interactive secondary action.
- Lets the bounded action row wrap only when available width is genuinely insufficient, preventing narrow-screen overflow while retaining a horizontal row at normal mobile widths.

## Accessibility
- The status remains explicit localized text inside `role=status`, so meaning does not depend on success color.
- The check SVG is `aria-hidden`.
- The status is a non-focusable `span` with no link, button, hover, pressed, focus, or shadow behavior.
- WhatsApp retains its existing accessible name, title, external-link target, and icon treatment.

## Behavior and scope
Ballot submission, `hasSubmitted`, status fetching, voting windows, WhatsApp URL/gating, lifecycle, authentication, Firebase reads/writes/schema/rules/indexes, providers, and routes are unchanged. The shared `BallotEntry` now presents the completed state consistently on Home and existing match entry surfaces.

## Responsive behavior
The status and action use bounded widths, a shrink-safe content wrapper, a fixed WhatsApp control, and graceful flex wrapping. The Spanish label and WhatsApp action fit as one row at normal mobile widths and cannot force horizontal overflow around 320px.

## Documentation
`DESIGN_SYSTEM.md` now records the compact, non-interactive submitted-status treatment as a durable UI rule. `PRODUCT.md`, `ARCHITECTURE.md`, and `PRODUCTION_RUNBOOK.md` were reviewed and do not need changes because product behavior, system boundaries, persistence, and operations are unchanged.

## Verification
- Focused submitted/Home/archive UI tests: 3 files, 37 tests passed
- `npm run verify`: passed; 46 test files / 288 tests and production build passed
- `npm run test:firebase`: passed; 7 test files / 49 tests
- `git diff --check`: passed