### PR TITLE
fix: add confirmed player identity aliases

### DIFF
--- a/PRODUCTION_RUNBOOK.md
+++ b/PRODUCTION_RUNBOOK.md
@@ -116,11 +116,11 @@ API-Football reminders such as name, shirt number, age, birth details, nationali
 
 After deploying the reviewed identity-aware release, use a controlled checkout of that same commit with the production Firebase Admin variables loaded and no emulator variables present:
 
-1. Preview the exact plan: `npm run reconcile:player-identities -- --project-id rating-app-prod-8b7df`.
-2. Require the dry run to select canonical Player `player-f020ba4cf4c187bcedb2255d`, retain legacy Player `player-971dc7fe3b5c761cf85fb321`, and propose only the missing aliases/metadata. Stop on any conflict or unexpected path.
-3. Apply once: `npm run reconcile:player-identities -- --project-id rating-app-prod-8b7df --apply true --confirm reconcile-player-identities`.
-4. Repeat the dry run and require zero alias or canonical metadata writes.
-5. Inspect `/players` and both prior profile URLs. Require one canonical S. Rodriguez entry with combined published history; do not edit Firestore manually.
+1. Preview the exact plan: `npx tsx scripts/reconcile-player-identities.ts --project-id rating-app-prod-8b7df`.
+2. Require the already-migrated S. Rodriguez reconciliation (`541314` → `36237`) to propose zero writes. Require only the reviewed E. Bravo (`669618` → `404115`) and K. Estrada (`628817` → `512850`) aliases plus any safe missing canonical metadata enrichment. Stop on any conflict or unexpected path.
+3. Apply once: `npx tsx scripts/reconcile-player-identities.ts --project-id rating-app-prod-8b7df --apply true --confirm reconcile-player-identities`.
+4. Repeat the dry run from step 1 and require zero alias or canonical metadata writes across every configured reconciliation.
+5. Inspect `/players` and each legacy/canonical profile URL pair. Require one canonical entry per reconciled player with combined published history; do not edit Firestore manually.
 
 The command rejects development/local mode, emulator hosts, demo projects, project mismatches, missing production Admin credentials, and an inexact apply confirmation. CI never runs it. Adding a future reconciliation requires confirming the real player identity independently, reviewing the canonical metadata choice and historical references, adding focused tests, deploying the code, and then following this dry-run/apply/dry-run sequence. Name-only or shirt-only merging is prohibited.
 

--- a/src/application/reconcile-player-identities.test.ts
+++ b/src/application/reconcile-player-identities.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  PLAYER_IDENTITY_RECONCILIATIONS,
+  proposedPlayerProviderAlias,
+} from "@/config/player-identity-reconciliations";
 import type { Player, PlayerProviderAlias } from "@/domain/models";
 import {
   playerProviderAliasId,
@@ -18,6 +22,90 @@ const canonicalId = providerEntityId("player", "api-football", "36237");
 const legacyId = providerEntityId("player", "api-football", "541314");
 
 describe("player identity reconciliation", () => {
+  it("plans and becomes idempotent for every configured reconciliation", () => {
+    for (const configured of PLAYER_IDENTITY_RECONCILIATIONS) {
+      const configuredCanonicalId = providerEntityId(
+        "player",
+        configured.externalProvider,
+        configured.canonicalExternalPlayerId,
+      );
+      const players = new Map(
+        configured.externalPlayerIds.map((externalPlayerId) => {
+          const id = providerEntityId(
+            "player",
+            configured.externalProvider,
+            externalPlayerId,
+          );
+          return [id, player(id, externalPlayerId, "attacker")] as const;
+        }),
+      );
+      const first = planPlayerIdentityReconciliation({
+        reconciliation: configured,
+        players,
+        persistedAliases: new Map(),
+        timestamp: now,
+      });
+
+      expect(first.canonicalPlayerId).toBe(configuredCanonicalId);
+      expect(first.aliasWrites).toHaveLength(2);
+      expect(
+        first.aliasWrites.every(
+          ({ canonicalPlayerId }) =>
+            canonicalPlayerId === configuredCanonicalId,
+        ),
+      ).toBe(true);
+
+      const second = planPlayerIdentityReconciliation({
+        reconciliation: configured,
+        players,
+        persistedAliases: new Map(
+          first.aliasWrites.map((alias) => [alias.id, alias]),
+        ),
+        timestamp: now,
+      });
+      expect(second.aliasWrites).toEqual([]);
+      expect(second.canonicalPlayerWrite).toBeNull();
+    }
+  });
+
+  it("keeps migrated Rodriguez aliases unchanged while planning only new pairs", () => {
+    const migratedRodriguezAliases = new Map(
+      ["36237", "541314"].map((externalPlayerId) => {
+        const alias = proposedPlayerProviderAlias(
+          "api-football",
+          externalPlayerId,
+          now,
+        );
+        return [alias.id, alias];
+      }),
+    );
+    const plannedAliasWrites = PLAYER_IDENTITY_RECONCILIATIONS.map(
+      (configured) => {
+        const players = new Map(
+          configured.externalPlayerIds.map((externalPlayerId) => {
+            const id = providerEntityId(
+              "player",
+              configured.externalProvider,
+              externalPlayerId,
+            );
+            return [id, player(id, externalPlayerId, "attacker")] as const;
+          }),
+        );
+        return planPlayerIdentityReconciliation({
+          reconciliation: configured,
+          players,
+          persistedAliases:
+            configured.canonicalExternalPlayerId === "36237"
+              ? migratedRodriguezAliases
+              : new Map(),
+          timestamp: now,
+        }).aliasWrites.length;
+      },
+    );
+
+    expect(plannedAliasWrites).toEqual([0, 2, 2]);
+  });
+
   it("keeps richer canonical metadata and plans both explicit aliases", () => {
     const plan = planPlayerIdentityReconciliation({
       reconciliation,

--- a/src/application/sync-match-participants.test.ts
+++ b/src/application/sync-match-participants.test.ts
@@ -18,24 +18,36 @@ describe("participant synchronization identities", () => {
     );
   });
 
-  it("uses a known alias for future match participants", async () => {
-    const store = storeWith();
-    await syncMatchParticipants(
-      match.id,
-      providerWith("541314"),
-      store,
-      new Date("2026-09-07T12:00:00.000Z"),
-    );
-    expect(vi.mocked(store.upsertPlayers).mock.calls[0][0][0].id).toBe(
-      providerEntityId("player", "api-football", "36237"),
-    );
-    expect(
-      vi.mocked(store.replaceMatchParticipants).mock.calls[0][1][0],
-    ).toMatchObject({
-      playerId: providerEntityId("player", "api-football", "36237"),
-      externalProviderPlayerId: "541314",
-    });
-  });
+  it.each([
+    ["S. Rodriguez", "541314", "36237"],
+    ["E. Bravo", "669618", "404115"],
+    ["K. Estrada", "628817", "512850"],
+  ])(
+    "uses the known %s alias for future match participants",
+    async (name, legacyExternalPlayerId, canonicalExternalPlayerId) => {
+      const store = storeWith();
+      await syncMatchParticipants(
+        match.id,
+        providerWith(legacyExternalPlayerId, name),
+        store,
+        new Date("2026-09-07T12:00:00.000Z"),
+      );
+      const canonicalPlayerId = providerEntityId(
+        "player",
+        "api-football",
+        canonicalExternalPlayerId,
+      );
+      expect(vi.mocked(store.upsertPlayers).mock.calls[0][0][0].id).toBe(
+        canonicalPlayerId,
+      );
+      expect(
+        vi.mocked(store.replaceMatchParticipants).mock.calls[0][1][0],
+      ).toMatchObject({
+        playerId: canonicalPlayerId,
+        externalProviderPlayerId: legacyExternalPlayerId,
+      });
+    },
+  );
 
   it("does not merge unknown players that share a name and shirt", async () => {
     const firstStore = storeWith();
@@ -86,7 +98,10 @@ const match: Match = {
   updatedAt: "2026-01-01T00:00:00.000Z",
 };
 
-function providerWith(externalPlayerId: string): FootballDataProvider {
+function providerWith(
+  externalPlayerId: string,
+  name = "S. Rodriguez",
+): FootballDataProvider {
   return {
     name: "api-football",
     requestCount: 1,
@@ -95,7 +110,7 @@ function providerWith(externalPlayerId: string): FootballDataProvider {
         {
           externalTeamId: "815",
           externalPlayerId,
-          name: "S. Rodriguez",
+          name,
           shirtNumber: 24,
           position: "midfielder",
           squadRole: "starter",

--- a/src/application/sync-player-squad.test.ts
+++ b/src/application/sync-player-squad.test.ts
@@ -53,22 +53,33 @@ describe("syncPlayerSquad", () => {
     expect(summary).toMatchObject({ squadSize: 1, apiRequests: 1 });
   });
 
-  it("resolves a known historical provider ID to the canonical Player", async () => {
-    const upsertPlayers = vi.fn().mockResolvedValue({
-      created: 0,
-      updated: 1,
-      unchanged: 0,
-    });
-    await syncPlayerSquad(
-      team.id,
-      providerWith([{ externalPlayerId: "541314", name: "S. Rodriguez" }]),
-      storeWith(upsertPlayers),
-    );
-    expect(upsertPlayers.mock.calls[0][0][0]).toMatchObject({
-      id: providerEntityId("player", "api-football", "36237"),
-      externalProviderId: "36237",
-    });
-  });
+  it.each([
+    ["S. Rodriguez", "541314", "36237"],
+    ["E. Bravo", "669618", "404115"],
+    ["K. Estrada", "628817", "512850"],
+  ])(
+    "resolves the known %s provider alias during future squad sync",
+    async (name, legacyExternalPlayerId, canonicalExternalPlayerId) => {
+      const upsertPlayers = vi.fn().mockResolvedValue({
+        created: 0,
+        updated: 1,
+        unchanged: 0,
+      });
+      await syncPlayerSquad(
+        team.id,
+        providerWith([{ externalPlayerId: legacyExternalPlayerId, name }]),
+        storeWith(upsertPlayers),
+      );
+      expect(upsertPlayers.mock.calls[0][0][0]).toMatchObject({
+        id: providerEntityId(
+          "player",
+          "api-football",
+          canonicalExternalPlayerId,
+        ),
+        externalProviderId: canonicalExternalPlayerId,
+      });
+    },
+  );
 
   it("omits missing optional metadata so persistence can preserve last-known values", async () => {
     const upsertPlayers = vi.fn().mockResolvedValue({
@@ -83,32 +94,6 @@ describe("syncPlayerSquad", () => {
     );
     expect(upsertPlayers.mock.calls[0][0][0]).not.toHaveProperty("position");
     expect(upsertPlayers.mock.calls[0][0][0]).not.toHaveProperty("photoUrl");
-  });
-
-  it("resolves a known historical provider ID to the canonical Player", async () => {
-    const upsertPlayers = vi.fn().mockResolvedValue({
-      created: 0,
-      updated: 1,
-      unchanged: 0,
-    });
-    await syncPlayerSquad(
-      team.id,
-      providerWith([
-        {
-          externalPlayerId: "541314",
-          name: "S. Rodriguez",
-          position: "midfielder",
-        },
-      ]),
-      storeWith(upsertPlayers),
-    );
-
-    expect(upsertPlayers).toHaveBeenCalledWith([
-      expect.objectContaining({
-        id: providerEntityId("player", "api-football", "36237"),
-        externalProviderId: "36237",
-      }),
-    ]);
   });
 
   it("rejects an empty usable squad instead of implying a destructive success", async () => {

--- a/src/config/player-identity-reconciliations.test.ts
+++ b/src/config/player-identity-reconciliations.test.ts
@@ -6,16 +6,39 @@ import { proposedPlayerProviderAlias } from "./player-identity-reconciliations";
 
 const timestamp = "2026-09-07T12:00:00.000Z";
 
+const reconciliations = [
+  ["S. Rodriguez", "541314", "36237", "player-f020ba4cf4c187bcedb2255d"],
+  ["E. Bravo", "669618", "404115", "player-497ecbd4e8df4c3996e95570"],
+  ["K. Estrada", "628817", "512850", "player-86124cff51a0d24f11270789"],
+] as const;
+
 describe("player identity reconciliations", () => {
-  it("maps both confirmed Rodriguez provider IDs to the richer canonical Player", () => {
-    const aliases = ["36237", "541314"].map((externalPlayerId) =>
-      proposedPlayerProviderAlias("api-football", externalPlayerId, timestamp),
-    );
-    expect(aliases.map(({ canonicalPlayerId }) => canonicalPlayerId)).toEqual([
-      providerEntityId("player", "api-football", "36237"),
-      providerEntityId("player", "api-football", "36237"),
-    ]);
-  });
+  it.each(reconciliations)(
+    "maps the confirmed %s provider IDs to one canonical Player",
+    (_name, legacyId, canonicalId, expectedPlayerId) => {
+      expect(providerEntityId("player", "api-football", canonicalId)).toBe(
+        expectedPlayerId,
+      );
+      const derivedPlayerId = providerEntityId(
+        "player",
+        "api-football",
+        canonicalId,
+      );
+      for (const externalPlayerId of [canonicalId, legacyId]) {
+        expect(
+          proposedPlayerProviderAlias(
+            "api-football",
+            externalPlayerId,
+            timestamp,
+          ),
+        ).toMatchObject({
+          canonicalPlayerId: derivedPlayerId,
+          canonicalExternalProviderPlayerId: canonicalId,
+          externalProviderPlayerId: externalPlayerId,
+        });
+      }
+    },
+  );
 
   it("keeps unknown provider IDs distinct without name or shirt heuristics", () => {
     const first = proposedPlayerProviderAlias(

--- a/src/config/player-identity-reconciliations.ts
+++ b/src/config/player-identity-reconciliations.ts
@@ -17,6 +17,16 @@ export const PLAYER_IDENTITY_RECONCILIATIONS: readonly PlayerIdentityReconciliat
       canonicalExternalPlayerId: "36237",
       externalPlayerIds: ["36237", "541314"],
     },
+    {
+      externalProvider: "api-football",
+      canonicalExternalPlayerId: "404115",
+      externalPlayerIds: ["404115", "669618"],
+    },
+    {
+      externalProvider: "api-football",
+      canonicalExternalPlayerId: "512850",
+      externalPlayerIds: ["512850", "628817"],
+    },
   ];
 
 export function proposedPlayerProviderAlias(

--- a/tests/firebase/player-history.test.ts
+++ b/tests/firebase/player-history.test.ts
@@ -146,6 +146,38 @@ describe("trusted player history reads", () => {
       rank: 1,
     });
   });
+
+  it.each([
+    ["E. Bravo", "bravo", "669618", "404115"],
+    ["K. Estrada", "estrada", "628817", "512850"],
+  ])(
+    "consolidates %s history and resolves the legacy profile route",
+    async (name, key, legacyExternalId, canonicalExternalId) => {
+      const { canonicalId, legacyId } = await seedAliasedHistory({
+        name,
+        key,
+        legacyExternalId,
+        canonicalExternalId,
+        position: "attacker",
+      });
+      const profile = await new AdminPlayerHistoryService(database).get(
+        legacyId,
+        teamId,
+      );
+
+      expect(profile).toMatchObject({
+        playerId: canonicalId,
+        playerName: name,
+        overallAverage: 8,
+        ratedMatchCount: 2,
+        recentRating: 9,
+        history: [
+          expect.objectContaining({ matchId: `${key}-new`, average: 9 }),
+          expect.objectContaining({ matchId: `${key}-old`, average: 7 }),
+        ],
+      });
+    },
+  );
 });
 
 async function seedMatch(
@@ -192,53 +224,76 @@ async function seedMatch(
   }
 }
 
-async function seedAliasedHistory() {
-  const canonicalId = providerEntityId("player", "api-football", "36237");
-  const legacyId = providerEntityId("player", "api-football", "541314");
+async function seedAliasedHistory(
+  identity: {
+    name: string;
+    key: string;
+    legacyExternalId: string;
+    canonicalExternalId: string;
+    position: "midfielder" | "attacker";
+  } = {
+    name: "S. Rodriguez",
+    key: "alias",
+    legacyExternalId: "541314",
+    canonicalExternalId: "36237",
+    position: "midfielder",
+  },
+) {
+  const canonicalId = providerEntityId(
+    "player",
+    "api-football",
+    identity.canonicalExternalId,
+  );
+  const legacyId = providerEntityId(
+    "player",
+    "api-football",
+    identity.legacyExternalId,
+  );
   const timestamp = Timestamp.fromDate(new Date("2026-09-01T00:00:00.000Z"));
   await Promise.all([
     database.doc(`players/${canonicalId}`).set({
-      displayName: "S. Rodriguez",
-      position: "midfielder",
+      displayName: identity.name,
+      position: identity.position,
       externalProvider: "api-football",
-      externalProviderId: "36237",
+      externalProviderId: identity.canonicalExternalId,
       createdAt: timestamp,
       updatedAt: timestamp,
     }),
     database.doc(`players/${legacyId}`).set({
-      displayName: "S. Rodriguez",
+      displayName: identity.name,
       externalProvider: "api-football",
-      externalProviderId: "541314",
+      externalProviderId: identity.legacyExternalId,
       createdAt: timestamp,
       updatedAt: timestamp,
     }),
-    ...["36237", "541314"].map((externalProviderPlayerId) =>
-      database
-        .doc(
-          `playerProviderAliases/${playerProviderAliasId(
-            "api-football",
+    ...[identity.canonicalExternalId, identity.legacyExternalId].map(
+      (externalProviderPlayerId) =>
+        database
+          .doc(
+            `playerProviderAliases/${playerProviderAliasId(
+              "api-football",
+              externalProviderPlayerId,
+            )}`,
+          )
+          .set({
+            canonicalPlayerId: canonicalId,
+            canonicalExternalProviderPlayerId: identity.canonicalExternalId,
+            externalProvider: "api-football",
             externalProviderPlayerId,
-          )}`,
-        )
-        .set({
-          canonicalPlayerId: canonicalId,
-          canonicalExternalProviderPlayerId: "36237",
-          externalProvider: "api-football",
-          externalProviderPlayerId,
-          createdAt: timestamp,
-          updatedAt: timestamp,
-        }),
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          }),
     ),
   ]);
   for (const [matchId, playerId, externalPlayerId, average] of [
-    ["alias-old", legacyId, "541314", 7],
-    ["alias-new", canonicalId, "36237", 9],
+    [`${identity.key}-old`, legacyId, identity.legacyExternalId, 7],
+    [`${identity.key}-new`, canonicalId, identity.canonicalExternalId, 9],
   ] as const) {
     await seedMatch(matchId, "rating_closed", timestamp);
     await database.doc(`matches/${matchId}/participants/${playerId}`).set({
       matchId,
       playerId,
-      playerName: "S. Rodriguez",
+      playerName: identity.name,
       teamId,
       externalProvider: "api-football",
       externalProviderTeamId: "815",
@@ -256,7 +311,7 @@ async function seedAliasedHistory() {
       playerResults: {
         [playerId]: {
           playerId,
-          playerName: "S. Rodriguez",
+          playerName: identity.name,
           average,
           voteCount: 2,
           order: 0,


### PR DESCRIPTION
Closes #56

## Summary

- add explicit API-Football identity reconciliations for E. Bravo (669618 -> 404115) and K. Estrada (628817 -> 512850)
- retain the existing S. Rodriguez reconciliation (541314 -> 36237) unchanged
- reuse the provider-ID alias architecture for future squad/participant sync and historical profile aggregation
- add table-driven unit and Firebase regression coverage
- update the production reconciliation checklist with the exact guarded dry-run/apply/dry-run commands

No fuzzy name, shirt-number, schema, domain-model, lifecycle, voting, or provider-sync redesign is included. Historical documents remain preserved and are resolved through aliases.

## Production operation

A guarded production reconciliation is required after this change is reviewed, merged, and deployed. It was not run as part of this PR.

1. npx tsx scripts/reconcile-player-identities.ts --project-id rating-app-prod-8b7df
2. npx tsx scripts/reconcile-player-identities.ts --project-id rating-app-prod-8b7df --apply true --confirm reconcile-player-identities
3. npx tsx scripts/reconcile-player-identities.ts --project-id rating-app-prod-8b7df

The final dry run must report zero pending writes. Any conflict or unexpected path must stop the operation.

## Verification

- focused unit/regression tests: 8 files, 62 tests passed
- focused Firebase history/profile tests: 1 file, 5 tests passed
- npm run test:firebase: 8 files, 59 tests passed
- npm run verify: 49 files, 310 tests passed; formatting, encoding, lint, strict typecheck, and production build passed
- git diff --check: passed

No secrets, environment files, or raw provider payloads were committed.