### PR TITLE
fix: make player evolution chart readable

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -88,6 +88,8 @@ Submission uses one focused confirmation dialog because ballots are immutable. I
 
 Final results use a scorecard hierarchy, not an analytics dashboard. The match score leads, a crisp secondary-accent block gives player MVP or co-MVP the strongest emphasis, ranked players use numbered inset rows, and the coach sits in a separate panel. Display averages use one decimal in score typography; names remain readable sans and wrap safely. Ranking and MVP labels must be explicit rather than color-only. Do not add traffic-light rating colors, glow, or casino treatment.
 
+Player evolution charts remain compact dark insets rather than analytics panels. Plot ratings against the fixed product scale of 1–10, label 10, 5, and 1 with only three low-contrast horizontal guides, and run history chronologically from left to right. Use localized short dates for horizontal context, thinning visible labels to a small representative set when history becomes dense. Every point must expose its exact one-decimal rating, opponent, and date through a viewport-bounded tooltip on pointer hover or focus, with a meaningful accessible label and visible keyboard focus. Do not auto-scale to observed results or rely on color alone.
+
 League standings use a compact fixed-layout table. At mobile widths show rank, Team, played, goal difference, and points; reveal wins, draws, and losses at wider widths. Team names truncate safely, numeric cells use score typography, and the configured Team receives a club-accent row marker plus a screen-reader label so identity is never color-only. Do not require horizontal scrolling at 320 px.
 
 ## Spacing and responsive behavior

--- a/src/components/player-history.test.tsx
+++ b/src/components/player-history.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type { PlayerCatalogEntry } from "@/application/player-history";
@@ -94,6 +94,9 @@ describe("player history UI", () => {
       "/matches/match-1/results",
     );
     expect(screen.getByText("vs Opponent")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("group", { name: /rating evolution/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders a known-player empty state", () => {
@@ -116,21 +119,69 @@ describe("player history UI", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders a lightweight accessible multi-match evolution graphic", () => {
+  it("renders the fixed rating scale, guides, and accessible match points", () => {
     render(
       <PlayerProfile
         player={player({
           ratedMatchCount: 2,
-          history: [history(), history({ matchId: "match-0", average: 7 })],
+          history: [
+            history(),
+            history({
+              matchId: "match-0",
+              kickoffAt: "2026-08-23T17:00:00.000Z",
+              opponentName: "Earlier Opponent",
+              average: 7,
+            }),
+          ],
         })}
         locale="en"
         messages={messages}
       />,
     );
 
-    expect(
-      screen.getByRole("img", { name: /rating evolution/i }),
-    ).toBeInTheDocument();
+    const chart = screen.getByRole("group", { name: /rating evolution/i });
+    expect(within(chart).getByText("10")).toBeInTheDocument();
+    expect(within(chart).getByText("5")).toBeInTheDocument();
+    expect(within(chart).getByText("1")).toBeInTheDocument();
+    expect(within(chart).getAllByTestId("rating-guide")).toHaveLength(3);
+    expect(within(chart).getAllByTestId("rating-point")).toHaveLength(2);
+    expect(within(chart).getAllByTestId("rating-axis-label")).toHaveLength(2);
+    expect(within(chart).getByText("8/23")).toBeInTheDocument();
+    expect(within(chart).getByText("8/30")).toBeInTheDocument();
+
+    const latestPoint = within(chart).getByRole("img", {
+      name: /vs Opponent, Aug 30, 2026: rating 8\.0/i,
+    });
+    expect(latestPoint).toHaveAttribute("tabindex", "0");
+    latestPoint.focus();
+    expect(latestPoint).toHaveFocus();
+    expect(within(chart).getByText("Rating 8.0")).toBeInTheDocument();
+    expect(within(chart).getByText("vs Earlier Opponent")).toBeInTheDocument();
+  });
+
+  it("thins dense date labels and keeps the chart bounded on narrow layouts", () => {
+    const denseHistory = Array.from({ length: 8 }, (_, index) =>
+      history({
+        matchId: `match-${index}`,
+        kickoffAt: `2026-08-${String(index + 1).padStart(2, "0")}T17:00:00.000Z`,
+        opponentName: `Opponent ${index + 1}`,
+        average: index + 1,
+      }),
+    ).reverse();
+    render(
+      <PlayerProfile
+        player={player({ ratedMatchCount: 8, history: denseHistory })}
+        locale="en"
+        messages={messages}
+      />,
+    );
+
+    const chart = screen.getByRole("group", { name: /rating evolution/i });
+    expect(within(chart).getAllByTestId("rating-point")).toHaveLength(8);
+    expect(within(chart).getAllByTestId("rating-axis-label")).toHaveLength(4);
+    expect(chart).toHaveAttribute("viewBox", "0 0 320 152");
+    expect(chart).toHaveClass("w-full", "max-w-full");
+    expect(chart.parentElement).toHaveClass("overflow-hidden");
   });
 });
 

--- a/src/components/player-history.tsx
+++ b/src/components/player-history.tsx
@@ -184,7 +184,11 @@ export function PlayerProfile({
                 </p>
               </div>
             ) : (
-              <RatingSparkline player={player} messages={messages} />
+              <RatingSparkline
+                player={player}
+                locale={locale}
+                messages={messages}
+              />
             )}
           </section>
 
@@ -244,19 +248,29 @@ export function PlayerProfile({
 
 function RatingSparkline({
   player,
+  locale,
   messages,
 }: {
   player: PlayerCatalogEntry;
+  locale: Locale;
   messages: PlayerMessages;
 }) {
   const chronological = [...player.history].reverse();
-  const points = chronological
-    .map((entry, index) => {
-      const x = 8 + (index / (chronological.length - 1)) * 184;
-      const y = 92 - ((entry.average - 1) / 9) * 84;
-      return `${x},${y}`;
-    })
-    .join(" ");
+  const plot = {
+    left: 28,
+    right: 312,
+    top: 12,
+    bottom: 116,
+  };
+  const plotted = chronological.map((entry, index) => ({
+    entry,
+    x:
+      plot.left +
+      (index / (chronological.length - 1)) * (plot.right - plot.left),
+    y: ratingToY(entry.average, plot.top, plot.bottom),
+  }));
+  const points = plotted.map(({ x, y }) => `${x},${y}`).join(" ");
+  const labeledPointIndexes = axisLabelIndexes(chronological.length);
   const label = messages.trendLabel
     .replace("{name}", player.playerName)
     .replace(
@@ -264,13 +278,46 @@ function RatingSparkline({
       chronological.map((entry) => rating(entry.average)).join(", "),
     );
   return (
-    <div className="game-inset mt-4 p-3">
+    <div className="game-inset mt-4 overflow-hidden p-3">
       <svg
-        viewBox="0 0 200 100"
-        role="img"
+        viewBox="0 0 320 152"
+        role="group"
         aria-label={label}
-        className="h-32 w-full"
+        className="h-44 w-full max-w-full"
+        preserveAspectRatio="xMidYMid meet"
       >
+        <title>{label}</title>
+        <g aria-hidden="true">
+          {[
+            { rating: 10, y: plot.top },
+            { rating: 5, y: ratingToY(5, plot.top, plot.bottom) },
+            { rating: 1, y: plot.bottom },
+          ].map((guide) => (
+            <g key={guide.rating}>
+              <text
+                x="21"
+                y={guide.y}
+                dy="0.35em"
+                textAnchor="end"
+                fill="var(--game-muted)"
+                fontSize="10"
+              >
+                {guide.rating}
+              </text>
+              <line
+                data-testid="rating-guide"
+                x1={plot.left}
+                x2={plot.right}
+                y1={guide.y}
+                y2={guide.y}
+                stroke="var(--game-border)"
+                strokeWidth="1"
+                strokeDasharray="2 3"
+                opacity="0.55"
+              />
+            </g>
+          ))}
+        </g>
         <polyline
           points={points}
           fill="none"
@@ -278,23 +325,153 @@ function RatingSparkline({
           strokeWidth="4"
           strokeLinejoin="miter"
         />
-        {chronological.map((entry, index) => {
-          const [cx, cy] = points.split(" ")[index].split(",");
+        {plotted.map(({ entry, x, y }, index) => {
+          const shortDate = formatDate(entry.kickoffAt, locale, {
+            day: "numeric",
+            month: "numeric",
+          });
+          const fullDate = formatDate(entry.kickoffAt, locale, {
+            dateStyle: "medium",
+          });
+          const pointLabel = messages.trendPointLabel
+            .replace("{opponent}", entry.opponentName)
+            .replace("{date}", fullDate)
+            .replace("{rating}", rating(entry.average));
+          const tooltipWidth = 152;
+          const tooltipHeight = 50;
+          const tooltipX = Math.min(
+            Math.max(x - tooltipWidth / 2, plot.left),
+            316 - tooltipWidth,
+          );
+          const tooltipY =
+            y < plot.top + tooltipHeight + 8 ? y + 10 : y - tooltipHeight - 8;
           return (
-            <circle
+            <g
               key={entry.matchId}
-              cx={cx}
-              cy={cy}
-              r="4"
-              fill="var(--club-primary)"
-              stroke="var(--game-text)"
-              strokeWidth="2"
-            />
+              data-testid="rating-point"
+              role="img"
+              aria-label={pointLabel}
+              tabIndex={0}
+              focusable="true"
+              className="group outline-none"
+            >
+              <circle cx={x} cy={y} r="12" fill="transparent" />
+              <circle
+                cx={x}
+                cy={y}
+                r="8"
+                fill="none"
+                stroke="var(--game-focus)"
+                strokeWidth="2"
+                className="opacity-0 group-focus:opacity-100"
+              />
+              <circle
+                cx={x}
+                cy={y}
+                r="4"
+                fill="var(--club-primary)"
+                stroke="var(--game-text)"
+                strokeWidth="2"
+              />
+              <g
+                aria-hidden="true"
+                className="pointer-events-none opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100 motion-reduce:transition-none"
+              >
+                <rect
+                  x={tooltipX}
+                  y={tooltipY}
+                  width={tooltipWidth}
+                  height={tooltipHeight}
+                  fill="var(--game-surface-raised)"
+                  stroke="var(--game-text)"
+                  strokeWidth="1"
+                />
+                <text
+                  x={tooltipX + 7}
+                  y={tooltipY + 15}
+                  fill="var(--club-secondary)"
+                  fontSize="11"
+                  className="score-font"
+                >
+                  {messages.trendRating.replace(
+                    "{rating}",
+                    rating(entry.average),
+                  )}
+                </text>
+                <text
+                  x={tooltipX + 7}
+                  y={tooltipY + 29}
+                  fill="var(--game-text)"
+                  fontSize="10"
+                >
+                  {truncate(
+                    messages.versus.replace("{opponent}", entry.opponentName),
+                    24,
+                  )}
+                </text>
+                <text
+                  x={tooltipX + 7}
+                  y={tooltipY + 42}
+                  fill="var(--game-muted)"
+                  fontSize="9"
+                >
+                  {fullDate}
+                </text>
+              </g>
+              {labeledPointIndexes.has(index) ? (
+                <g aria-hidden="true">
+                  <line
+                    x1={x}
+                    x2={x}
+                    y1={plot.bottom}
+                    y2={plot.bottom + 4}
+                    stroke="var(--game-muted)"
+                    strokeWidth="1"
+                  />
+                  <text
+                    data-testid="rating-axis-label"
+                    x={x}
+                    y="139"
+                    textAnchor={
+                      index === 0
+                        ? "start"
+                        : index === chronological.length - 1
+                          ? "end"
+                          : "middle"
+                    }
+                    fill="var(--game-muted)"
+                    fontSize="9"
+                  >
+                    {shortDate}
+                  </text>
+                </g>
+              ) : null}
+            </g>
           );
         })}
       </svg>
     </div>
   );
+}
+
+function ratingToY(value: number, top: number, bottom: number) {
+  return bottom - ((value - 1) / 9) * (bottom - top);
+}
+
+function axisLabelIndexes(length: number) {
+  if (length <= 5) return new Set(Array.from({ length }, (_, index) => index));
+  return new Set([
+    0,
+    Math.round((length - 1) / 3),
+    Math.round(((length - 1) * 2) / 3),
+    length - 1,
+  ]);
+}
+
+function truncate(value: string, maximumLength: number) {
+  return value.length <= maximumLength
+    ? value
+    : `${value.slice(0, maximumLength - 1)}…`;
 }
 
 function matchCount(count: number, messages: PlayerMessages) {

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -197,6 +197,8 @@ export const enMessages = {
     viewResults: "View results",
     back: "Back to players",
     trendLabel: "{name} rating evolution: {ratings}",
+    trendPointLabel: "vs {opponent}, {date}: rating {rating}",
+    trendRating: "Rating {rating}",
     avatarLabel: "Avatar for {name}",
     positions: {
       goalkeeper: "Goalkeeper",

--- a/src/i18n/messages/es.ts
+++ b/src/i18n/messages/es.ts
@@ -203,6 +203,8 @@ export const esMessages = {
     viewResults: "Ver resultados",
     back: "Volver a jugadores",
     trendLabel: "Evolución de {name}: {ratings}",
+    trendPointLabel: "vs {opponent}, {date}: calificación {rating}",
+    trendRating: "Calificación {rating}",
     avatarLabel: "Avatar de {name}",
     positions: {
       goalkeeper: "Portero",


### PR DESCRIPTION
Closes #58

## UX problem

The compact Evolucion/Evolution graphic showed only a trend line and points, so its fixed rating meaning and the match behind each point were not readable.

## Implementation

- keep the existing dark inset, yellow trend line, and red/white point treatment
- plot every value against the fixed Rating App 1-10 scale
- label 10, 5, and 1 with three quiet dashed horizontal guides
- show localized short dates from oldest to newest along the X axis
- show every date for up to five matches, then intentionally thin labels to four representative dates for dense history
- expose a bounded tooltip for every point with its one-decimal rating, opponent, and localized date
- make each point focusable with a complete accessible label and a visible focus ring; hover and focus reveal the same tooltip, and touch focus uses the same disclosure
- retain a responsive 320-unit SVG viewBox, full-width sizing, edge-aware labels, clamped tooltips, and an overflow-bounded inset

This remains a Server Component and uses the existing player-history DTO. No chart library, provider call, Firebase read, schema/index change, backfill, route change, or new client boundary was added. Rating calculations, history aggregation, player identity, ranking, Firebase, and provider behavior are unchanged.

## Verification

- focused player history UI suite: 1 file, 7 tests passed
- npm run verify: passed formatting, encoding, lint, strict typecheck, 310 tests, and production build
- npm run test:firebase: 8 files, 59 tests passed
- git diff --check: passed
- no separate player-detail E2E/Playwright/Cypress suite exists in the repository

Coverage includes the fixed 1-10 labels, guide lines, point count, exact rating and opponent/date context, keyboard focus, compact date labels, dense-history thinning, bounded narrow layout structure, one-match behavior, and empty history.

## Documentation

DESIGN_SYSTEM.md now records the durable fixed-scale, guide, date-label, tooltip, focus, and dense-history behavior. PRODUCT.md was reviewed and unchanged because product calculations and capabilities did not change. ARCHITECTURE.md was reviewed and unchanged because no dependency, schema, boundary, or data-read path changed. PRODUCTION_RUNBOOK.md was reviewed and unchanged because there is no operational change.